### PR TITLE
AHOYAPPS-136: Lock app to portrait orientation

### DIFF
--- a/VideoApp/VideoApp/Info.plist
+++ b/VideoApp/VideoApp/Info.plist
@@ -56,8 +56,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-136

### Changes

1. Lock orientation to portrait for entire app.

### Testing

1. Verify app does not allow rotation.