### PR TITLE
AHOYAPPS-84: Remove associated domains

### DIFF
--- a/VideoApp/VideoApp/Video.entitlements
+++ b/VideoApp/VideoApp/Video.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:video.bytwilio.com</string>
-	</array>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-84

### Changes

1. Associated domains causes build error for developer customer that is not a member of Twilio developer team. Since this is only used for deep links and we aren't really using deep links right now just remove. We can revisit later when we want to get deep links working.

### Testing

1. Made sure build succeeded with Apple developer account that was not on Twilio team.