### PR TITLE
AHOYAPPS-314: Unpublish video in background

### DIFF
--- a/VideoApp/VideoApp/Video/LocalMediaController+Internal.h
+++ b/VideoApp/VideoApp/Video/LocalMediaController+Internal.h
@@ -18,6 +18,8 @@
 
 @interface LocalMediaController (Internal)
 
+- (void)cameraSourceWasInterrupted;
+- (void)cameraSourceInterruptionEnded;
 - (void)videoCaptureStarted;
 
 @end

--- a/VideoApp/VideoApp/Video/LocalMediaController.m
+++ b/VideoApp/VideoApp/Video/LocalMediaController.m
@@ -162,4 +162,16 @@
     }
 }
 
+- (void)cameraSourceWasInterrupted {
+    if (self.camera.localVideoTrack) {
+        [self.localParticipant unpublishVideoTrack:self.camera.localVideoTrack];
+    }
+}
+
+- (void)cameraSourceInterruptionEnded {
+    if (self.camera.localVideoTrack) {
+        [self.localParticipant publishVideoTrack:self.camera.localVideoTrack];
+    }
+}
+
 @end

--- a/VideoApp/VideoApp/Video/VideoAppCameraSource.m
+++ b/VideoApp/VideoApp/Video/VideoAppCameraSource.m
@@ -177,11 +177,11 @@ TVIVideoFormat *VideoAppCameraSourceSelectVideoFormatBySize(AVCaptureDevice *dev
 #pragma mark - TVICameraSourceDelegate
 
 - (void)cameraSourceInterruptionEnded:(TVICameraSource *)source {
-
+    [self.localMediaController cameraSourceInterruptionEnded];
 }
 
 - (void)cameraSourceWasInterrupted:(TVICameraSource *)source reason:(AVCaptureSessionInterruptionReason)reason {
-
+    [self.localMediaController cameraSourceWasInterrupted];
 }
 
 - (void)cameraSource:(TVICameraSource *)source didFailWithError:(NSError *)error {


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-314

#### Changes

1. Just unpublish video when app is in background and publish again when app returns to foreground.

#### Testing

1. Use video with 2 participants and make sure participant A sees participant B video change to muted when participant B sends app to background. And make sure participant A sees participant B video unmute when participant B returns app to foreground. 