### PR TITLE
AHOYAPPS-321: Fix iOS 12 settings bug

### DIFF
--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -171,6 +171,9 @@
 		DC6EABBD2357CA2E0064E9E0 /* MockFirebaseAuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6EABBC2357CA2E0064E9E0 /* MockFirebaseAuthStore.swift */; };
 		DC6EABBF2357CAC50064E9E0 /* MockAppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6EABBE2357CAC50064E9E0 /* MockAppSettingsStore.swift */; };
 		DC6EABC12357CB440064E9E0 /* MockTwilioVideoAppAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6EABC02357CB440064E9E0 /* MockTwilioVideoAppAPI.swift */; };
+		DC82A34F23FC9AAA0081578C /* CodableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* CodableContainer.swift */; };
+		DC82A35023FC9AAA0081578C /* CodableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* CodableContainer.swift */; };
+		DC82A35123FC9AAA0081578C /* CodableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* CodableContainer.swift */; };
 		DC85CA3F23BBCC8400BF016F /* MockURLOpenerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC85CA3E23BBCC8400BF016F /* MockURLOpenerFactory.swift */; };
 		DC85CA4123BBCCB000BF016F /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC85CA4023BBCCB000BF016F /* MockURLOpener.swift */; };
 		DC85CA4323BBCCC800BF016F /* MockLaunchStoresFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC85CA4223BBCCC800BF016F /* MockLaunchStoresFactory.swift */; };
@@ -491,6 +494,7 @@
 		DC6EABBC2357CA2E0064E9E0 /* MockFirebaseAuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFirebaseAuthStore.swift; sourceTree = "<group>"; };
 		DC6EABBE2357CAC50064E9E0 /* MockAppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSettingsStore.swift; sourceTree = "<group>"; };
 		DC6EABC02357CB440064E9E0 /* MockTwilioVideoAppAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTwilioVideoAppAPI.swift; sourceTree = "<group>"; };
+		DC82A34E23FC9AAA0081578C /* CodableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableContainer.swift; sourceTree = "<group>"; };
 		DC85CA3E23BBCC8400BF016F /* MockURLOpenerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpenerFactory.swift; sourceTree = "<group>"; };
 		DC85CA4023BBCCB000BF016F /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		DC85CA4223BBCCC800BF016F /* MockLaunchStoresFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchStoresFactory.swift; sourceTree = "<group>"; };
@@ -920,6 +924,7 @@
 			children = (
 				DC044683238EF6C20072F597 /* APIEnvironment.swift */,
 				DC4E4E1E23577EA700C5D313 /* AppSettingsStore.swift */,
+				DC82A34E23FC9AAA0081578C /* CodableContainer.swift */,
 				DC0446DA23A40E3E0072F597 /* Storage.swift */,
 				DC4E4E2223577EE500C5D313 /* Topology.swift */,
 				DCAEBF5223849C1C00141D2D /* VideoCodec.swift */,
@@ -2099,6 +2104,7 @@
 				DCD7675623DF554A00A2939C /* UserActivityStore.swift in Sources */,
 				DCAEBF302383560500141D2D /* EditTextCell.swift in Sources */,
 				DCAEBF14238331A800141D2D /* SwitchCell.swift in Sources */,
+				DC82A34F23FC9AAA0081578C /* CodableContainer.swift in Sources */,
 				DC8EAE3F23BA926E0045018F /* VideoStore.swift in Sources */,
 				DC8EAE2F23BA5EC80045018F /* AppDelegate.swift in Sources */,
 				24A723E31ECE1C8500486E7A /* StatsViewController.m in Sources */,
@@ -2199,6 +2205,7 @@
 				DCD7675723DF554A00A2939C /* UserActivityStore.swift in Sources */,
 				DCAEBF312383560500141D2D /* EditTextCell.swift in Sources */,
 				DCAEBF15238331A800141D2D /* SwitchCell.swift in Sources */,
+				DC82A35023FC9AAA0081578C /* CodableContainer.swift in Sources */,
 				DC8EAE4023BA926E0045018F /* VideoStore.swift in Sources */,
 				DC8EAE3023BA5EC80045018F /* AppDelegate.swift in Sources */,
 				4B0012261FBA52C4004A587E /* StatsViewController.m in Sources */,
@@ -2299,6 +2306,7 @@
 				DCD7675823DF554B00A2939C /* UserActivityStore.swift in Sources */,
 				DCAEBF322383560500141D2D /* EditTextCell.swift in Sources */,
 				DCAEBF16238331A800141D2D /* SwitchCell.swift in Sources */,
+				DC82A35123FC9AAA0081578C /* CodableContainer.swift in Sources */,
 				DC8EAE4123BA926E0045018F /* VideoStore.swift in Sources */,
 				DC8EAE3123BA5EC80045018F /* AppDelegate.swift in Sources */,
 				4B0012631FBA52E5004A587E /* StatsViewController.m in Sources */,

--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -171,9 +171,9 @@
 		DC6EABBD2357CA2E0064E9E0 /* MockFirebaseAuthStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6EABBC2357CA2E0064E9E0 /* MockFirebaseAuthStore.swift */; };
 		DC6EABBF2357CAC50064E9E0 /* MockAppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6EABBE2357CAC50064E9E0 /* MockAppSettingsStore.swift */; };
 		DC6EABC12357CB440064E9E0 /* MockTwilioVideoAppAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6EABC02357CB440064E9E0 /* MockTwilioVideoAppAPI.swift */; };
-		DC82A34F23FC9AAA0081578C /* CodableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* CodableContainer.swift */; };
-		DC82A35023FC9AAA0081578C /* CodableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* CodableContainer.swift */; };
-		DC82A35123FC9AAA0081578C /* CodableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* CodableContainer.swift */; };
+		DC82A34F23FC9AAA0081578C /* JSONContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* JSONContainer.swift */; };
+		DC82A35023FC9AAA0081578C /* JSONContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* JSONContainer.swift */; };
+		DC82A35123FC9AAA0081578C /* JSONContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82A34E23FC9AAA0081578C /* JSONContainer.swift */; };
 		DC85CA3F23BBCC8400BF016F /* MockURLOpenerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC85CA3E23BBCC8400BF016F /* MockURLOpenerFactory.swift */; };
 		DC85CA4123BBCCB000BF016F /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC85CA4023BBCCB000BF016F /* MockURLOpener.swift */; };
 		DC85CA4323BBCCC800BF016F /* MockLaunchStoresFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC85CA4223BBCCC800BF016F /* MockLaunchStoresFactory.swift */; };
@@ -494,7 +494,7 @@
 		DC6EABBC2357CA2E0064E9E0 /* MockFirebaseAuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFirebaseAuthStore.swift; sourceTree = "<group>"; };
 		DC6EABBE2357CAC50064E9E0 /* MockAppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSettingsStore.swift; sourceTree = "<group>"; };
 		DC6EABC02357CB440064E9E0 /* MockTwilioVideoAppAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTwilioVideoAppAPI.swift; sourceTree = "<group>"; };
-		DC82A34E23FC9AAA0081578C /* CodableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableContainer.swift; sourceTree = "<group>"; };
+		DC82A34E23FC9AAA0081578C /* JSONContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONContainer.swift; sourceTree = "<group>"; };
 		DC85CA3E23BBCC8400BF016F /* MockURLOpenerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpenerFactory.swift; sourceTree = "<group>"; };
 		DC85CA4023BBCCB000BF016F /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		DC85CA4223BBCCC800BF016F /* MockLaunchStoresFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchStoresFactory.swift; sourceTree = "<group>"; };
@@ -924,7 +924,7 @@
 			children = (
 				DC044683238EF6C20072F597 /* APIEnvironment.swift */,
 				DC4E4E1E23577EA700C5D313 /* AppSettingsStore.swift */,
-				DC82A34E23FC9AAA0081578C /* CodableContainer.swift */,
+				DC82A34E23FC9AAA0081578C /* JSONContainer.swift */,
 				DC0446DA23A40E3E0072F597 /* Storage.swift */,
 				DC4E4E2223577EE500C5D313 /* Topology.swift */,
 				DCAEBF5223849C1C00141D2D /* VideoCodec.swift */,
@@ -2104,7 +2104,7 @@
 				DCD7675623DF554A00A2939C /* UserActivityStore.swift in Sources */,
 				DCAEBF302383560500141D2D /* EditTextCell.swift in Sources */,
 				DCAEBF14238331A800141D2D /* SwitchCell.swift in Sources */,
-				DC82A34F23FC9AAA0081578C /* CodableContainer.swift in Sources */,
+				DC82A34F23FC9AAA0081578C /* JSONContainer.swift in Sources */,
 				DC8EAE3F23BA926E0045018F /* VideoStore.swift in Sources */,
 				DC8EAE2F23BA5EC80045018F /* AppDelegate.swift in Sources */,
 				24A723E31ECE1C8500486E7A /* StatsViewController.m in Sources */,
@@ -2205,7 +2205,7 @@
 				DCD7675723DF554A00A2939C /* UserActivityStore.swift in Sources */,
 				DCAEBF312383560500141D2D /* EditTextCell.swift in Sources */,
 				DCAEBF15238331A800141D2D /* SwitchCell.swift in Sources */,
-				DC82A35023FC9AAA0081578C /* CodableContainer.swift in Sources */,
+				DC82A35023FC9AAA0081578C /* JSONContainer.swift in Sources */,
 				DC8EAE4023BA926E0045018F /* VideoStore.swift in Sources */,
 				DC8EAE3023BA5EC80045018F /* AppDelegate.swift in Sources */,
 				4B0012261FBA52C4004A587E /* StatsViewController.m in Sources */,
@@ -2306,7 +2306,7 @@
 				DCD7675823DF554B00A2939C /* UserActivityStore.swift in Sources */,
 				DCAEBF322383560500141D2D /* EditTextCell.swift in Sources */,
 				DCAEBF16238331A800141D2D /* SwitchCell.swift in Sources */,
-				DC82A35123FC9AAA0081578C /* CodableContainer.swift in Sources */,
+				DC82A35123FC9AAA0081578C /* JSONContainer.swift in Sources */,
 				DC8EAE4123BA926E0045018F /* VideoStore.swift in Sources */,
 				DC8EAE3123BA5EC80045018F /* AppDelegate.swift in Sources */,
 				4B0012631FBA52E5004A587E /* StatsViewController.m in Sources */,

--- a/VideoApp/VideoApp/Stores/AppSettings/CodableContainer.swift
+++ b/VideoApp/VideoApp/Stores/AppSettings/CodableContainer.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (C) 2020 Twilio, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+// Prior to iOS 13 JSONEncoder and JSONDecoder require the top-level type to be an Array, Dictionary, or Struct.
+// Use this container to encode and decode any type by wrapping it in a Struct.
+// https://stackoverflow.com/questions/50257242/jsonencoder-wont-allow-type-encoded-to-primitive-value
+struct CodableContainer<T: Codable>: Codable {
+    let value: T
+}

--- a/VideoApp/VideoApp/Stores/AppSettings/JSONContainer.swift
+++ b/VideoApp/VideoApp/Stores/AppSettings/JSONContainer.swift
@@ -19,6 +19,6 @@ import Foundation
 // Prior to iOS 13 JSONEncoder and JSONDecoder require the top-level type to be an Array, Dictionary, or Struct.
 // Use this container to encode and decode any type by wrapping it in a Struct.
 // https://stackoverflow.com/questions/50257242/jsonencoder-wont-allow-type-encoded-to-primitive-value
-struct CodableContainer<T: Codable>: Codable {
+struct JSONContainer<T: Codable>: Codable {
     let value: T
 }

--- a/VideoApp/VideoApp/Stores/AppSettings/Storage.swift
+++ b/VideoApp/VideoApp/Stores/AppSettings/Storage.swift
@@ -30,14 +30,17 @@ struct Storage<T: Codable> {
 
     var wrappedValue: T {
         get {
-            guard let data = userDefaults.object(forKey: key) as? Data, let value = try? JSONDecoder().decode(T.self, from: data) else {
-                return defaultValue
+            guard
+                let data = userDefaults.object(forKey: key) as? Data,
+                let container = try? JSONDecoder().decode(CodableContainer<T>.self, from: data)
+                else {
+                    return defaultValue
             }
-            
-            return value
+
+            return container.value
         }
         set {
-            let data = try? JSONEncoder().encode(newValue)
+            let data = try? JSONEncoder().encode(CodableContainer(value: newValue))
             userDefaults.set(data, forKey: key)
         }
     }

--- a/VideoApp/VideoApp/Stores/AppSettings/Storage.swift
+++ b/VideoApp/VideoApp/Stores/AppSettings/Storage.swift
@@ -32,7 +32,7 @@ struct Storage<T: Codable> {
         get {
             guard
                 let data = userDefaults.object(forKey: key) as? Data,
-                let container = try? JSONDecoder().decode(CodableContainer<T>.self, from: data)
+                let container = try? JSONDecoder().decode(JSONContainer<T>.self, from: data)
                 else {
                     return defaultValue
             }
@@ -40,7 +40,7 @@ struct Storage<T: Codable> {
             return container.value
         }
         set {
-            let data = try? JSONEncoder().encode(CodableContainer(value: newValue))
+            let data = try? JSONEncoder().encode(JSONContainer(value: newValue))
             userDefaults.set(data, forKey: key)
         }
     }


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-321

#### Changes

1. iOS 12 has a bug that causes JSONEncoder and JSONDecoder to fail with valid JSON. To avoid the problem wrap each setting in a container struct. A little unusual but least bad option I think. This way we can still use Codable objects to store settings. When we drop iOS 12 in the future we could consider reverting this change with or without a migration. The worst that should happen is app settings would be reset.

#### Testing

1. Tested settings on iOS 11, 12, and 13.