### PR TITLE
Update readme for passcode sign in

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ iOS Deployment Target | Xcode Version | Swift Language Version
 
 ## Getting Started
 
+### Deploy Twilio Access Token Server
+
+The app requires a back-end to generate [Twilio access tokens](https://www.twilio.com/docs/video/tutorials/user-identity-access-tokens). Follow the instructions below to deploy a serverless back-end using [Twilio Functions](https://www.twilio.com/docs/runtime/functions).
+
+1. [Install Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart).
+1. Run `twilio plugins:install @twilio/labs/plugin-rtc`
+1. Run `twilio rtc:video:deploy-app --authentication passcode`
+1. The passcode that is output will be used later to [sign in to the app](#start-video-conference).
+
+The passcode will expire after one week. To generate a new passcode:
+
+1. Run `twilio rtc:video:delete-app`
+1. Run `twilio rtc:video:deploy-app --authentication passcode`
+
 ### Install Dependencies
 
 1. Install [CocoaPods](https://cocoapods.org).
@@ -33,15 +47,6 @@ iOS Deployment Target | Xcode Version | Swift Language Version
 1. In Xcode navigate to the [Signing & Capabilities pane](https://developer.apple.com/documentation/xcode/adding_capabilities_to_your_app) of the project editor for the `Video-Community` target.
 1. Change `Team` to your team.
 1. Change `Bundle identifier` to something unique.
-
-### Generate Twilio Access Token
-
-1. Use the Twilio Console to [generate a Twilio Access Token](https://www.twilio.com/docs/video/tutorials/user-identity-access-tokens#generate-in-console). It is not necessary to enter a room name.
-1. Replace `TWILIO_ACCESS_TOKEN` in [CommunityAuthStore.swift](https://github.com/twilio/twilio-video-app-ios/blob/master/VideoApp/VideoApp/Stores/Auth/Community/CommunityAuthStore.swift) with your Twilio access token.
-
-Twilio access tokens generated with Twilio Console are valid for one hour. Repeat the steps above to refresh an expired Twilio access token.
-
-This manual process for generating a Twilio access token minimizes setup but it is only useful for testing. To automate generation of Twilio access tokens for a production app see [User Identify & Access Tokens documentation](https://www.twilio.com/docs/video/tutorials/user-identity-access-tokens).
 
 ### Run
 
@@ -55,9 +60,18 @@ The `Video-Twilio` and `Video-Internal` schemes use authentication that is only 
 
 For each device:
 
-1. Use a different identity to [generate a Twilio access token](#generate-twilio-access-token) and [run](#run). 
+1. [Run](#run) the app.
+1. Enter any unique name in the `Your name` field.
+1. Enter the passcode from [Deploy Twilio Access Token Server](#deploy-twilio-access-token-server) in the `Passcode` field.
+1. Tap `Sign in`.
 1. Enter a room name.
 1. Tap `Join`.
+
+The passcode will expire after one week. Follow the steps below to sign in with a new passcode.
+
+1. [Generate a new passcode](#deploy-twilio-access-token-server).
+1. In the app tap `Settings > Sign Out`.
+1. Repeat the [steps above](#start-video-conference).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ iOS Deployment Target | Xcode Version | Swift Language Version
 The app requires a back-end to generate [Twilio access tokens](https://www.twilio.com/docs/video/tutorials/user-identity-access-tokens). Follow the instructions below to deploy a serverless back-end using [Twilio Functions](https://www.twilio.com/docs/runtime/functions).
 
 1. [Install Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart).
-1. Run `twilio plugins:install @twilio/labs/plugin-rtc`
-1. Run `twilio rtc:video:deploy-app --authentication passcode`
+1. Run `twilio plugins:install @twilio/labs/plugin-rtc`.
+1. Run `twilio rtc:video:deploy-app --authentication passcode`.
 1. The passcode that is output will be used later to [sign in to the app](#start-video-conference).
 
 The passcode will expire after one week. To generate a new passcode:
 
-1. Run `twilio rtc:video:delete-app`
-1. Run `twilio rtc:video:deploy-app --authentication passcode`
+1. Run `twilio rtc:video:delete-app`.
+1. Run `twilio rtc:video:deploy-app --authentication passcode`.
 
 ### Install Dependencies
 


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-342

Until the new Twilio CLI plugin is public if we want to test we must replace this instruction:

- Run `twilio plugins:install @twilio/labs/plugin-rtc`.

With these instructions:

- Clone https://github.com/twilio-labs/plugin-rtc.
- Checkout `development` branch.
- Run `npm install`.
- Run `twilio plugins:link <PATH_TO_PLUGIN_REPO>`.