### PR TITLE
Deploy community build to App Center

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,9 @@ workflows:
           filters: *test_filters
       - run_ui_tests:
           filters: *test_filters
-      - deploy_internal_app_beta:
-          filters:
-            branches:
-              only:
-                - master
+      # - deploy_internal_app_beta:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      - deploy_internal_app_beta

--- a/.circleci/setup_code_signing.sh
+++ b/.circleci/setup_code_signing.sh
@@ -4,6 +4,8 @@
 mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles || true
 base64 -D <<< $INTERNAL_DISTRIBUTION_PROVISIONING_PROFILE -o ~/Library/MobileDevice/Provisioning\ Profiles/internal_distribution.mobileprovision
 base64 -D <<< $INTERNAL_DEVELOPMENT_PROVISIONING_PROFILE -o ~/Library/MobileDevice/Provisioning\ Profiles/internal_development.mobileprovision
+base64 -D <<< $COMMUNITY_DISTRIBUTION_PROVISIONING_PROFILE -o ~/Library/MobileDevice/Provisioning\ Profiles/community_distribution.mobileprovision
+base64 -D <<< $COMMUNITY_DEVELOPMENT_PROVISIONING_PROFILE -o ~/Library/MobileDevice/Provisioning\ Profiles/community_development.mobileprovision
 
 # Install certificates
 base64 -D <<< $APPLE_WORLDWIDE_DEVELOPER_RELATIONS_CERTIFICATE_AUTHORITY_CER -o Apple\ Worldwide\ Developer\ Relations\ Certification\ Authority.cer

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,14 +12,14 @@ platform :ios do
   end
 
   lane :beta do
-    ensure_git_status_clean
-    increment_build_number(xcodeproj: "VideoApp/VideoApp.xcodeproj")
-    commit_version_bump(message: "Increment build number [skip ci]", xcodeproj: "VideoApp/VideoApp.xcodeproj")
-    add_git_tag
-    push_to_git_remote
+    # ensure_git_status_clean
+    # increment_build_number(xcodeproj: "VideoApp/VideoApp.xcodeproj")
+    # commit_version_bump(message: "Increment build number [skip ci]", xcodeproj: "VideoApp/VideoApp.xcodeproj")
+    # add_git_tag
+    # push_to_git_remote
 
     gym(
-      scheme: "Video-Internal",
+      scheme: "Video-Community",
       export_options: {
         method: "enterprise",
         compileBitcode: false,
@@ -27,7 +27,7 @@ platform :ios do
         signingStyle: "manual",
         signingCertificate: "iPhone Distribution: Twilio, Inc.",
         provisioningProfiles: {
-          "com.twilio.video-app-internal" => "VideoApp-Internal-Distribution"
+          "com.twilio.video-app-community" => "VideoApp-Community-Distribution"
         }
       }
     ) 
@@ -37,9 +37,9 @@ platform :ios do
     appcenter_upload(
       api_token: ENV["APP_CENTER_API_KEY"],
       owner_name: ENV["APP_CENTER_OWNER_NAME"],
-      app_name: "Ahoy-Video-App-Internal",
+      app_name: "Ahoy-Video-App-Community",
       destinations: "Testers",
-      file: "Video-Internal.ipa"
+      file: "Video-Community.ipa"
     )
   end
 end


### PR DESCRIPTION
This is for a demo and won't be merged until we clean it up.

1. Deploys community build to App Center on any push.
1. Does not increment build number.
1. Disables deployment of internal build to App Center on merge to master.
1. In-app updates do not work for community build.

Public App Center link:

https://install.appcenter.ms/orgs/nico-hokeyapp-dzyz/apps/ahoy-video-app-community/distribution_groups/testers