### PR TITLE
Add Twilio CLI login instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ iOS Deployment Target | Xcode Version | Swift Language Version
 The app requires a back-end to generate [Twilio access tokens](https://www.twilio.com/docs/video/tutorials/user-identity-access-tokens). Follow the instructions below to deploy a serverless back-end using [Twilio Functions](https://www.twilio.com/docs/runtime/functions).
 
 1. [Install Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart).
+1. Run `twilio login` and follow prompts to [login to your Twilio account](https://www.twilio.com/docs/twilio-cli/quickstart#login-to-your-twilio-account).
 1. Run `twilio plugins:install @twilio-labs/plugin-rtc`.
 1. Run `twilio rtc:apps:video:deploy --authentication passcode`.
 1. The passcode that is output will be used later to [sign in to the app](#start-video-conference).


### PR DESCRIPTION
A customer had a problem getting started and I think it was caused by skipping `twilio login`. After looking closer I realized that login really is separate from install and so it should be a separate step.