### PR TITLE
Status check workaround

### DIFF
--- a/VideoApp/Video-TwilioUITests/Activities/AuthActivities.swift
+++ b/VideoApp/Video-TwilioUITests/Activities/AuthActivities.swift
@@ -43,8 +43,9 @@ class AuthActivities {
 
     static func signOut() {
         XCTContext.runActivity(named: "Sign out") { _ in
-            expect(app.buttons["settingsButton"].exists).toEventually(beTrue()) // Prevent intermittent failure on simulator
-            app.buttons["settingsButton"].tap()
+            let settingsButton = app.buttons["settingsButton"]
+            expect(settingsButton.exists).toEventually(beTrue()) // Prevent intermittent failure on simulator
+            settingsButton.tap()
             app.tables/*@START_MENU_TOKEN@*/.staticTexts["Sign Out"]/*[[".cells.staticTexts[\"Sign Out\"]",".staticTexts[\"Sign Out\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
         }
     }

--- a/VideoApp/Video-TwilioUITests/Activities/AuthActivities.swift
+++ b/VideoApp/Video-TwilioUITests/Activities/AuthActivities.swift
@@ -43,6 +43,7 @@ class AuthActivities {
 
     static func signOut() {
         XCTContext.runActivity(named: "Sign out") { _ in
+            expect(app.buttons["settingsButton"].exists).toEventually(beTrue()) // Prevent intermittent failure on simulator
             app.buttons["settingsButton"].tap()
             app.tables/*@START_MENU_TOKEN@*/.staticTexts["Sign Out"]/*[[".cells.staticTexts[\"Sign Out\"]",".staticTexts[\"Sign Out\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
         }


### PR DESCRIPTION
Having issues with the UI test. So force the test to wait for the settings button to be available.

There is a separate ticket to run tests on real hardware which seems reliable.