### PR TITLE
Remove sign out from status check test

### DIFF
--- a/VideoApp/Video-TwilioUITests/Activities/AuthActivities.swift
+++ b/VideoApp/Video-TwilioUITests/Activities/AuthActivities.swift
@@ -43,9 +43,7 @@ class AuthActivities {
 
     static func signOut() {
         XCTContext.runActivity(named: "Sign out") { _ in
-            let settingsButton = app.buttons["settingsButton"]
-            expect(settingsButton.exists).toEventually(beTrue()) // Prevent intermittent failure on simulator
-            settingsButton.tap()
+            app.buttons["settingsButton"].tap()
             app.tables/*@START_MENU_TOKEN@*/.staticTexts["Sign Out"]/*[[".cells.staticTexts[\"Sign Out\"]",".staticTexts[\"Sign Out\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
         }
     }

--- a/VideoApp/Video-TwilioUITests/Plans/UI.xctestplan
+++ b/VideoApp/Video-TwilioUITests/Plans/UI.xctestplan
@@ -13,6 +13,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "RoomTests\/test_joinRoom_withFooRoomName_shouldDisplayFooRoomNameOnRoomScreen()"
+      ],
       "target" : {
         "containerPath" : "container:VideoApp.xcodeproj",
         "identifier" : "DC044678238DD55C0072F597",

--- a/VideoApp/Video-TwilioUITests/Tests/DeepLinkTests.swift
+++ b/VideoApp/Video-TwilioUITests/Tests/DeepLinkTests.swift
@@ -20,7 +20,7 @@ class DeepLinkTests: BasicTestCase {
     func test_roomDeepLink_withUserSignedIn_shouldNavigateToLobbyScreenAndSetRoomName() {
         AuthActivities.signIn()
         DeepLinkActivities.open(url: "https://twilio-video-react.appspot.com/room/foo") {
-            expect(app.textFields["roomNameTextField"].value as? String).to(equal("foo"))
+            expect(app.textFields["roomNameTextField"].value as? String).toEventually(equal("foo"))
             AuthActivities.signOut()
         }
     }
@@ -28,7 +28,7 @@ class DeepLinkTests: BasicTestCase {
     func test_roomDeepLink_withUserSignedOut_shouldRequireUserToSignInAndNavigateToLobbyScreenAndSetRoomName() {
         DeepLinkActivities.open(url: "https://twilio-video-react.appspot.com/room/foo") {
             AuthActivities.signIn()
-            expect(app.textFields["roomNameTextField"].value as? String).to(equal("foo"))
+            expect(app.textFields["roomNameTextField"].value as? String).toEventually(equal("foo"))
             AuthActivities.signOut()
         }
     }

--- a/VideoApp/Video-TwilioUITests/Tests/RoomTests.swift
+++ b/VideoApp/Video-TwilioUITests/Tests/RoomTests.swift
@@ -16,8 +16,9 @@
 
 import Nimble
 
-class RoomTests: SignedInTestCase {
+class RoomTests: BasicTestCase {
     func test_joinRoom_withFooRoomName_shouldDisplayFooRoomNameOnRoomScreen() {
+        AuthActivities.signIn()
         RoomActivities.join(roomName: "ios status check")
         expect(app.staticTexts["roomNameLabel"].label).toEventually(equal("ios status check"))
         RoomActivities.leave()


### PR DESCRIPTION
1. Removed sign out workaround I added yesterday because it didn't work on CI even though it seemed to locally.
1. Remove sign out from join room test that is used for status check.
1. Remove join room test from main UI test plan because it will cause issues with sign out removed.