### PR TITLE
AHOYAPPS-681: Fix track switch off UI bug

### DIFF
--- a/VideoApp/VideoApp/Views/VideoView/VideoView.swift
+++ b/VideoApp/VideoApp/Views/VideoView/VideoView.swift
@@ -41,7 +41,6 @@ class VideoView: NibView {
         super.awakeFromNib()
         
         videoView.delegate = self
-        isHidden = true
     }
 
     func configure(config: Config, contentMode: UIView.ContentMode = .scaleAspectFit) {
@@ -65,7 +64,7 @@ class VideoView: NibView {
     }
     
     private func updateStatus(hasVideoData: Bool) {
-        isHidden = !hasVideoData
+        videoView.isHidden = !hasVideoData
         delegate?.didUpdateStatus(isVideoOn: hasVideoData)
     }
 }

--- a/VideoApp/VideoApp/Views/VideoView/VideoView.xib
+++ b/VideoApp/VideoApp/Views/VideoView/VideoView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -18,7 +18,7 @@
             <rect key="frame" x="0.0" y="0.0" width="338" height="543"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bnz-gB-mOY" userLabel="Video" customClass="TVIVideoView">
+                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bnz-gB-mOY" userLabel="Video" customClass="TVIVideoView">
                     <rect key="frame" x="0.0" y="0.0" width="338" height="543"/>
                     <color key="backgroundColor" red="0.1999788582" green="0.20001345870000001" blue="0.1999712884" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-681

The entire VideoApp.VideoView was hidden until we received a video frame. So if a track was switched off and we didn't have a frame the track switch off UI was not visible. To fix this only hide TwilioVideo.VideoView when there are no frames. 

I wanted to be surgical with this fix but in the future I think I may:

1. Separate error UI from this view so that it is really only doing video stuff.
1. When this view is displayed as the main video view and the track switch off UI is visible it is going to darken more of the view than is ideal. This is because in this case `contentMode = .scaleAspectFit`. And so it's going to darken not only the video but the empty space that the video did not take up. However this should never really happen because video in the main view should always have high priority and not get switched off. Because it should never happen and it is only a small cosmetic issue it is not a big deal right now. Would like to make it right sometime though. This is not a problem for participant list because the video fills the entire view.