### PR TITLE
Use documented best practices for codec settings

### DIFF
--- a/VideoApp/VideoApp/Stores/AppSettings/AppSettingsStore.swift
+++ b/VideoApp/VideoApp/Stores/AppSettings/AppSettingsStore.swift
@@ -39,7 +39,7 @@ protocol AppSettingsStoreWriting: LaunchStore {
 
 class AppSettingsStore: AppSettingsStoreWriting {
     @Storage(key: makeKey("environment"), defaultValue: Environment.production) var environment: Environment
-    @Storage(key: makeKey("videoCodec"), defaultValue: VideoCodec.vp8Simulcast) var videoCodec: VideoCodec
+    @Storage(key: makeKey("videoCodec"), defaultValue: VideoCodec.vp8SimulcastVGA) var videoCodec: VideoCodec
     @Storage(key: makeKey("topology"), defaultValue: Topology.group) var topology: Topology
     @Storage(key: makeKey("userIdentity"), defaultValue: "") var userIdentity: String
     @Storage(key: makeKey("isTURNMediaRelayOn"), defaultValue: false) var isTURNMediaRelayOn: Bool

--- a/VideoApp/VideoApp/Stores/AppSettings/VideoCodec.swift
+++ b/VideoApp/VideoApp/Stores/AppSettings/VideoCodec.swift
@@ -19,13 +19,15 @@ import Foundation
 enum VideoCodec: String, SettingOptions {
     case h264
     case vp8
-    case vp8Simulcast
+    case vp8SimulcastVGA
+    case vp8SimulcastHD
     
     var title: String {
         switch self {
         case .h264: return "H.264"
         case .vp8: return "VP8"
-        case .vp8Simulcast: return "VP8 Simulcast"
+        case .vp8SimulcastVGA: return "VP8 Simulcast VGA"
+        case .vp8SimulcastHD: return "VP8 Simulcast HD"
         }
     }
 }

--- a/VideoApp/VideoApp/Video/Room/ConnectOptionsFactory.swift
+++ b/VideoApp/VideoApp/Video/Room/ConnectOptionsFactory.swift
@@ -26,6 +26,15 @@ import TwilioVideo
         videoTracks: [TwilioVideo.LocalVideoTrack]
     ) -> ConnectOptions {
         ConnectOptions(token: accessToken) { builder in
+            var videoBitrate: UInt {
+                switch self.appSettingsStore.videoCodec {
+                case .h264: return 1_200
+                case .vp8: return 1_200
+                case .vp8SimulcastVGA: return 0
+                case .vp8SimulcastHD: return 1_600
+                }
+            }
+            
             builder.roomName = roomName
             builder.audioTracks = audioTracks
             builder.videoTracks = videoTracks
@@ -50,7 +59,7 @@ import TwilioVideo
                 }
             )
             builder.preferredVideoCodecs = [TwilioVideo.VideoCodec.make(setting: self.appSettingsStore.videoCodec)]
-            builder.encodingParameters = EncodingParameters(audioBitrate: 16, videoBitrate: 0)
+            builder.encodingParameters = EncodingParameters(audioBitrate: 16, videoBitrate: videoBitrate)
             
             if self.appSettingsStore.isTURNMediaRelayOn {
                 builder.iceOptions = IceOptions() { builder in

--- a/VideoApp/VideoApp/Video/Room/ConnectOptionsFactory.swift
+++ b/VideoApp/VideoApp/Video/Room/ConnectOptionsFactory.swift
@@ -49,20 +49,8 @@ import TwilioVideo
                     builder.renderDimensions = renderDimensions
                 }
             )
-
-            switch self.appSettingsStore.videoCodec {
-            case .h264:
-                builder.preferredVideoCodecs = [H264Codec()]
-                builder.encodingParameters = EncodingParameters(audioBitrate: 0, videoBitrate: 1_200)
-            case .vp8:
-                builder.preferredVideoCodecs = [Vp8Codec(simulcast: false)]
-                builder.encodingParameters = EncodingParameters(audioBitrate: 0, videoBitrate: 1_200)
-            case .vp8Simulcast:
-                builder.preferredVideoCodecs = [Vp8Codec(simulcast: true)]
-                
-                // Allocate a higher bitrate for the simulcast track with 3 spatial layers
-                builder.encodingParameters = EncodingParameters(audioBitrate: 0, videoBitrate: 1_600)
-            }
+            builder.preferredVideoCodecs = [TwilioVideo.VideoCodec.make(setting: self.appSettingsStore.videoCodec)]
+            builder.encodingParameters = EncodingParameters(audioBitrate: 16, videoBitrate: 0)
             
             if self.appSettingsStore.isTURNMediaRelayOn {
                 builder.iceOptions = IceOptions() { builder in
@@ -71,6 +59,16 @@ import TwilioVideo
                     builder.transportPolicy = .relay
                 }
             }
+        }
+    }
+}
+
+private extension TwilioVideo.VideoCodec {
+    static func make(setting: VideoCodec) -> TwilioVideo.VideoCodec {
+        switch setting {
+        case .h264: return H264Codec()
+        case .vp8: return Vp8Codec(simulcast: false)
+        case .vp8SimulcastVGA, .vp8SimulcastHD: return Vp8Codec(simulcast: true)
         }
     }
 }

--- a/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
+++ b/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
@@ -25,30 +25,26 @@ class CameraConfigFactory {
     private let appSettingsStore: AppSettingsStoreWriting = AppSettingsStore.shared
     
     func makeCameraConfigFactory(captureDevice: AVCaptureDevice) -> CameraConfig {
-        let targetSize: CMVideoDimensions
-        let cropRatio: CGFloat
-        let frameRate: UInt
-        
-        switch appSettingsStore.videoCodec {
-        case .h264, .vp8:
-            // 640 x 480 squarish crop (1.13:1)
-            targetSize = CMVideoDimensions(width: 544, height: 480)
-            
-            cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
-            frameRate = 20
-        case .vp8SimulcastVGA:
-            targetSize = CMVideoDimensions(width: 640, height: 480)
-            cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
-            frameRate = 24 // With VGA simulcast enabled there are 3 temporal layers, allowing a frame rate of {f, f/2, f/4}
-        case .vp8SimulcastHD:
-            // 1024 x 768 squarish crop (1.25:1) on most iPhones. 1280 x 720 squarish crop (1.25:1) on the iPhone X
-            // and models that don't have 1024 x 768.
-            targetSize = CMVideoDimensions(width: 900, height: 720)
-            
-            cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
-            frameRate = 24 // With HD simulcast enabled there are 3 temporal layers, allowing a frame rate of {f, f/2, f/4}
+        var targetSize: CMVideoDimensions {
+            switch appSettingsStore.videoCodec {
+            case .h264, .vp8, .vp8SimulcastVGA:
+                // 640 x 480 squarish crop (1.13:1)
+                return CMVideoDimensions(width: 544, height: 480)
+            case .vp8SimulcastHD:
+                // 1024 x 768 squarish crop (1.25:1) on most iPhones. 1280 x 720 squarish crop (1.25:1) on the iPhone X
+                // and models that don't have 1024 x 768.
+                return CMVideoDimensions(width: 900, height: 720)
+            }
         }
-        
+        var frameRate: UInt {
+            switch appSettingsStore.videoCodec {
+            case .h264, .vp8:
+                return 20
+            case .vp8SimulcastVGA, .vp8SimulcastHD:
+                return 24 // With simulcast enabled there are 3 temporal layers, allowing a frame rate of {f, f/2, f/4}
+            }
+        }
+        let cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
         let preferredFormat = selectVideoFormatBySize(captureDevice: captureDevice, targetSize: targetSize)
         preferredFormat.frameRate = min(preferredFormat.frameRate, frameRate)
         

--- a/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
+++ b/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
@@ -46,7 +46,7 @@ class CameraConfigFactory {
             targetSize = CMVideoDimensions(width: 900, height: 720)
             
             cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
-            frameRate = 24 // With HD simulcast enabled there are 3 temporal layers, allowing a frame rate of f/4
+            frameRate = 24 // With HD simulcast enabled there are 3 temporal layers, allowing a frame rate of {f, f/2, f/4}
         }
         
         let preferredFormat = selectVideoFormatBySize(captureDevice: captureDevice, targetSize: targetSize)

--- a/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
+++ b/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
@@ -36,13 +36,17 @@ class CameraConfigFactory {
             
             cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
             frameRate = 20
-        case .vp8Simulcast:
+        case .vp8SimulcastVGA:
+            targetSize = CMVideoDimensions(width: 640, height: 480)
+            cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
+            frameRate = 24 // With VGA simulcast enabled there are 2 temporal layers, allowing a frame rate of f/4
+        case .vp8SimulcastHD:
             // 1024 x 768 squarish crop (1.25:1) on most iPhones. 1280 x 720 squarish crop (1.25:1) on the iPhone X
             // and models that don't have 1024 x 768.
             targetSize = CMVideoDimensions(width: 900, height: 720)
             
             cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
-            frameRate = 24 // With simulcast enabled there are 3 temporal layers, allowing a frame rate of f/4
+            frameRate = 24 // With HD simulcast enabled there are 3 temporal layers, allowing a frame rate of f/4
         }
         
         let preferredFormat = selectVideoFormatBySize(captureDevice: captureDevice, targetSize: targetSize)

--- a/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
+++ b/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
@@ -39,7 +39,7 @@ class CameraConfigFactory {
         case .vp8SimulcastVGA:
             targetSize = CMVideoDimensions(width: 640, height: 480)
             cropRatio = CGFloat(targetSize.width) / CGFloat(targetSize.height)
-            frameRate = 24 // With VGA simulcast enabled there are 2 temporal layers, allowing a frame rate of f/4
+            frameRate = 24 // With VGA simulcast enabled there are 3 temporal layers, allowing a frame rate of {f, f/2, f/4}
         case .vp8SimulcastHD:
             // 1024 x 768 squarish crop (1.25:1) on most iPhones. 1280 x 720 squarish crop (1.25:1) on the iPhone X
             // and models that don't have 1024 x 768.


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-670

1. Used best practices outlined in ticket.
1. Added `VP8 Simulcast VGA` option to video codec setting.
1. Because I renamed `vp8Simulcast` to `vp8SimulcastHD` the video codec setting may be reset to default value when the software is installed which is actually a good thing.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-28 at 09 58 42](https://user-images.githubusercontent.com/1930363/83171394-48507f00-a0d3-11ea-9db0-3ee26eb5a122.png)