### PR TITLE
Fix retain cycle

### DIFF
--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewController.swift
@@ -37,10 +37,10 @@ class RoomViewController: UIViewController {
         participantCollectionView.delegate = self
         participantCollectionView.register(ParticipantCell.self)
 
-        disableMicButton.didToggle = { self.viewModel.isMicOn = !$0 }
-        disableCameraButton.didToggle = {
-            self.viewModel.isCameraOn = !$0
-            self.updateView()
+        disableMicButton.didToggle = { [weak self] in self?.viewModel.isMicOn = !$0 }
+        disableCameraButton.didToggle = { [weak self] in
+            self?.viewModel.isCameraOn = !$0
+            self?.updateView()
         }
 
         viewModel.delegate = self


### PR DESCRIPTION
Simple retain cycle that caused us to leak RoomViewController which then caused a lot of things to be leaked.

This does not seem to fix the camera problem when app returns to foreground.