### PR TITLE
Disable instead of unpublish when video source is interrupted

### DIFF
--- a/VideoApp/VideoApp/Video/Participants/LocalParticipant.swift
+++ b/VideoApp/VideoApp/Video/Participants/LocalParticipant.swift
@@ -164,11 +164,12 @@ extension LocalParticipant: LocalParticipantDelegate {
 
 extension LocalParticipant: CameraManagerDelegate {
     func trackSourceWasInterrupted(track: LocalVideoTrack) {
-        participant?.unpublishVideoTrack(track.track)
+        // Disable instead of unpublish to work around SDK bug https://issues.corp.twilio.com/browse/AHOYAPPS-701
+        track.track.isEnabled = false
     }
     
     func trackSourceInterruptionEnded(track: LocalVideoTrack) {
-        participant?.publishCameraTrack(track.track)
+        track.track.isEnabled = true
     }
 }
 


### PR DESCRIPTION
This is to work around an SDK bug.