### PR TITLE
AHOYAPPS-708: Prevent unnecessary video track priority updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ target 'Video-Twilio' do
   pod 'FirebaseUI/Google', '8.4.0'
   pod 'IGListDiffKit', '4.0.0'
   pod 'KeychainAccess', '4.1.0'
-  pod 'TwilioVideo', '3.4.0-rc2'
+  pod 'TwilioVideo', '3.4.0-rc3'
 
   target 'Video-TwilioTests' do
     pod 'Nimble'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -108,7 +108,7 @@ PODS:
   - nanopb/encode (0.3.9011)
   - Nimble (8.0.5)
   - Quick (2.2.0)
-  - TwilioVideo (3.4.0-rc2)
+  - TwilioVideo (3.4.0-rc3)
 
 DEPENDENCIES:
   - Alamofire (= 5.0.2)
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - KeychainAccess (= 4.1.0)
   - Nimble
   - Quick
-  - TwilioVideo (= 3.4.0-rc2)
+  - TwilioVideo (= 3.4.0-rc3)
 
 SPEC REPOS:
   "git@github.com:twilio/cocoapod-specs-internal.git":
@@ -181,8 +181,8 @@ SPEC CHECKSUMS:
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   Nimble: 4ab1aeb9b45553c75b9687196b0fa0713170a332
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
-  TwilioVideo: 99c5ef36cbb7528eb8ea3b38dc43cdb2f981f800
+  TwilioVideo: d9526612d2fec61d2a0ab33a58ca11dcf9eea1c1
 
-PODFILE CHECKSUM: d640cfcd2c50801d0fd5d961d980c1f5ad4e8d85
+PODFILE CHECKSUM: 0589974c4407d4aab742222043dd91da353871b0
 
 COCOAPODS: 1.8.4

--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -92,6 +92,9 @@
 		DC2511AB2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2511AA2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift */; };
 		DC2511AC2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2511AA2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift */; };
 		DC2511AD2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2511AA2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift */; };
+		DC2511B3248921CD00C776D6 /* ParticipantDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2511B2248921CD00C776D6 /* ParticipantDelegate.swift */; };
+		DC2511B4248921CD00C776D6 /* ParticipantDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2511B2248921CD00C776D6 /* ParticipantDelegate.swift */; };
+		DC2511B5248921CD00C776D6 /* ParticipantDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2511B2248921CD00C776D6 /* ParticipantDelegate.swift */; };
 		DC386DD12458DC05009E994A /* RoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC386DD02458DC05009E994A /* RoomViewModel.swift */; };
 		DC386DD22458DC05009E994A /* RoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC386DD02458DC05009E994A /* RoomViewModel.swift */; };
 		DC386DD32458DC05009E994A /* RoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC386DD02458DC05009E994A /* RoomViewModel.swift */; };
@@ -300,9 +303,6 @@
 		DC9A5E4B2463575F00E4B079 /* UserStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E4A2463575F00E4B079 /* UserStoreFactory.swift */; };
 		DC9A5E4C2463575F00E4B079 /* UserStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E4A2463575F00E4B079 /* UserStoreFactory.swift */; };
 		DC9A5E4D2463575F00E4B079 /* UserStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E4A2463575F00E4B079 /* UserStoreFactory.swift */; };
-		DC9A5E4F246366D500E4B079 /* LocalParticipantFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E4E246366D500E4B079 /* LocalParticipantFactory.swift */; };
-		DC9A5E50246366D500E4B079 /* LocalParticipantFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E4E246366D500E4B079 /* LocalParticipantFactory.swift */; };
-		DC9A5E51246366D500E4B079 /* LocalParticipantFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E4E246366D500E4B079 /* LocalParticipantFactory.swift */; };
 		DC9A5E5324638A9C00E4B079 /* ShowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E5224638A9C00E4B079 /* ShowError.swift */; };
 		DC9A5E5424638A9C00E4B079 /* ShowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E5224638A9C00E4B079 /* ShowError.swift */; };
 		DC9A5E5524638A9C00E4B079 /* ShowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A5E5224638A9C00E4B079 /* ShowError.swift */; };
@@ -675,6 +675,7 @@
 		DC1C2F9523AC35E40044FB4D /* AppInfoStoreSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoStoreSpec.swift; sourceTree = "<group>"; };
 		DC2511A6247817C600C776D6 /* EditMaxTracksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMaxTracksViewModel.swift; sourceTree = "<group>"; };
 		DC2511AA2478213400C776D6 /* EditMaxSubscriptionBitrateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMaxSubscriptionBitrateViewModel.swift; sourceTree = "<group>"; };
+		DC2511B2248921CD00C776D6 /* ParticipantDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantDelegate.swift; sourceTree = "<group>"; };
 		DC338A2724367AEC0093E855 /* Unit.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Unit.xctestplan; sourceTree = "<group>"; };
 		DC338A292437E7380093E855 /* StatusCheck.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StatusCheck.xctestplan; sourceTree = "<group>"; };
 		DC338A2A2437E7380093E855 /* UI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UI.xctestplan; sourceTree = "<group>"; };
@@ -761,7 +762,6 @@
 		DC9A5E422463247700E4B079 /* CircleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleButton.swift; sourceTree = "<group>"; };
 		DC9A5E462463345F00E4B079 /* LobbyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbyViewController.swift; sourceTree = "<group>"; };
 		DC9A5E4A2463575F00E4B079 /* UserStoreFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStoreFactory.swift; sourceTree = "<group>"; };
-		DC9A5E4E246366D500E4B079 /* LocalParticipantFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalParticipantFactory.swift; sourceTree = "<group>"; };
 		DC9A5E5224638A9C00E4B079 /* ShowError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowError.swift; sourceTree = "<group>"; };
 		DCA53947235F53E700CA26FB /* InternalAuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalAuthStore.swift; sourceTree = "<group>"; };
 		DCA5394B235F740200CA26FB /* AuthStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStore.swift; sourceTree = "<group>"; };
@@ -1688,8 +1688,8 @@
 			isa = PBXGroup;
 			children = (
 				DC9A5DCD245B0E6100E4B079 /* LocalParticipant.swift */,
-				DC9A5E4E246366D500E4B079 /* LocalParticipantFactory.swift */,
 				DC9A5DBF2459F1D100E4B079 /* Participant.swift */,
+				DC2511B2248921CD00C776D6 /* ParticipantDelegate.swift */,
 				DC9A5DD1245B332D00E4B079 /* RemoteParticipant.swift */,
 			);
 			path = Participants;
@@ -2764,6 +2764,7 @@
 				DCEDB39F2476C531006AF70D /* SelectHighRenderDimensionsViewModelFactory.swift in Sources */,
 				DCF461592385A51700DD8FEA /* SettingsViewController.swift in Sources */,
 				DCB7C1852405BD68009DEA70 /* API.swift in Sources */,
+				DC2511B3248921CD00C776D6 /* ParticipantDelegate.swift in Sources */,
 				24A723EE1ECE1D2A00486E7A /* TrackStatsTableViewCell.m in Sources */,
 				DCAEBF3B2384448500141D2D /* SelectOptionViewController.swift in Sources */,
 				DCEDB37E247447D3006AF70D /* SelectTrackSwitchOffModeViewModelFactory.swift in Sources */,
@@ -2827,7 +2828,6 @@
 				DC8AA8CF2367A10E006C06D5 /* TestAppDelegate.swift in Sources */,
 				DCF461652385B17A00DD8FEA /* AdvancedSettingsViewControllerFactory.swift in Sources */,
 				DC1C2F8623A6E7050044FB4D /* DispatchQueueProtocol.swift in Sources */,
-				DC9A5E4F246366D500E4B079 /* LocalParticipantFactory.swift in Sources */,
 				DCC7E36124082EB300431AC3 /* AuthError.swift in Sources */,
 				DCAEBF1C2383342C00141D2D /* DestructiveButtonCell.swift in Sources */,
 				DC9A5E3B2463161400E4B079 /* CircleView.swift in Sources */,
@@ -2935,6 +2935,7 @@
 				DCEDB3A02476C531006AF70D /* SelectHighRenderDimensionsViewModelFactory.swift in Sources */,
 				DCF4615A2385A51700DD8FEA /* SettingsViewController.swift in Sources */,
 				DCB7C1862405BD68009DEA70 /* API.swift in Sources */,
+				DC2511B4248921CD00C776D6 /* ParticipantDelegate.swift in Sources */,
 				4B0012291FBA52C4004A587E /* TrackStatsTableViewCell.m in Sources */,
 				DCAEBF3C2384448500141D2D /* SelectOptionViewController.swift in Sources */,
 				DCEDB37F247447D3006AF70D /* SelectTrackSwitchOffModeViewModelFactory.swift in Sources */,
@@ -2998,7 +2999,6 @@
 				DC8AA8D02367A10E006C06D5 /* TestAppDelegate.swift in Sources */,
 				DCF461662385B17A00DD8FEA /* AdvancedSettingsViewControllerFactory.swift in Sources */,
 				DC1C2F8723A6E7050044FB4D /* DispatchQueueProtocol.swift in Sources */,
-				DC9A5E50246366D500E4B079 /* LocalParticipantFactory.swift in Sources */,
 				DCC7E36224082EB300431AC3 /* AuthError.swift in Sources */,
 				DCAEBF1D2383342C00141D2D /* DestructiveButtonCell.swift in Sources */,
 				DC9A5E3C2463161400E4B079 /* CircleView.swift in Sources */,
@@ -3106,6 +3106,7 @@
 				DCEDB3A12476C531006AF70D /* SelectHighRenderDimensionsViewModelFactory.swift in Sources */,
 				DCF4615B2385A51700DD8FEA /* SettingsViewController.swift in Sources */,
 				DCB7C1872405BD68009DEA70 /* API.swift in Sources */,
+				DC2511B5248921CD00C776D6 /* ParticipantDelegate.swift in Sources */,
 				4B0012661FBA52E5004A587E /* TrackStatsTableViewCell.m in Sources */,
 				DCAEBF3D2384448500141D2D /* SelectOptionViewController.swift in Sources */,
 				DCEDB380247447D3006AF70D /* SelectTrackSwitchOffModeViewModelFactory.swift in Sources */,
@@ -3169,7 +3170,6 @@
 				DC8AA8D12367A10E006C06D5 /* TestAppDelegate.swift in Sources */,
 				DCF461672385B17A00DD8FEA /* AdvancedSettingsViewControllerFactory.swift in Sources */,
 				DC1C2F8823A6E7050044FB4D /* DispatchQueueProtocol.swift in Sources */,
-				DC9A5E51246366D500E4B079 /* LocalParticipantFactory.swift in Sources */,
 				DCC7E36324082EB300431AC3 /* AuthError.swift in Sources */,
 				DCAEBF1E2383342C00141D2D /* DestructiveButtonCell.swift in Sources */,
 				DC9A5E3D2463161400E4B079 /* CircleView.swift in Sources */,

--- a/VideoApp/VideoApp/Helpers/Notifications.swift
+++ b/VideoApp/VideoApp/Helpers/Notifications.swift
@@ -19,7 +19,6 @@ import Foundation
 extension Notification.Name {
     static let appSettingDidChange = Notification.Name("AppSettingDidChange")
     static let roomUpdate = Notification.Name("RoomUpdate")
-    static let participantUpdate = Notification.Name("ParticipantUpdate")
     static let participantsStoreUpdate = Notification.Name("ParticipantsStoreUpdate")
     static let mainParticipantStoreUpdate = Notification.Name("MainParticipantStoreUpdate")
 }

--- a/VideoApp/VideoApp/Stores/MainParticipant/MainParticipantStore.swift
+++ b/VideoApp/VideoApp/Stores/MainParticipant/MainParticipantStore.swift
@@ -49,7 +49,6 @@ class MainParticipantStore {
         videoTrack = mainParticipant.mainVideoTrack
         update()
         notificationCenter.addObserver(self, selector: #selector(update), name: .roomUpdate, object: room)
-        notificationCenter.addObserver(self, selector: #selector(update), name: .participantUpdate, object: nil)
         notificationCenter.addObserver(self, selector: #selector(update), name: .participantsStoreUpdate, object: participantsStore)
     }
     

--- a/VideoApp/VideoApp/Video/Participants/LocalParticipant.swift
+++ b/VideoApp/VideoApp/Video/Participants/LocalParticipant.swift
@@ -42,7 +42,7 @@ class LocalParticipant: NSObject, Participant {
                 self.micTrack = nil
             }
 
-            postUpdate()
+            sendUpdate()
         }
     }
     var isPinned = false
@@ -69,7 +69,7 @@ class LocalParticipant: NSObject, Participant {
                 self.cameraManager = nil
             }
 
-            postUpdate()
+            sendUpdate()
         }
     }
     var participant: TwilioVideo.LocalParticipant? {
@@ -100,30 +100,23 @@ class LocalParticipant: NSObject, Participant {
     var cameraPosition: AVCaptureDevice.Position = .front {
         didSet {
             cameraManager?.position = cameraPosition
-            postUpdate()
+            sendUpdate()
         }
     }
+    weak var delegate: ParticipantDelegate?
     private(set) var micTrack: LocalAudioTrack?
     private let micTrackFactory: MicTrackFactory
     private let cameraManagerFactory: CameraManagerFactory
-    private let notificationCenter: NotificationCenter
     private var cameraManager: CameraManager?
 
-    init(
-        identity: String,
-        micTrackFactory: MicTrackFactory,
-        cameraManagerFactory: CameraManagerFactory,
-        notificationCenter: NotificationCenter
-    ) {
+    init(identity: String, micTrackFactory: MicTrackFactory, cameraManagerFactory: CameraManagerFactory) {
         self.identity = identity
         self.micTrackFactory = micTrackFactory
         self.cameraManagerFactory = cameraManagerFactory
-        self.notificationCenter = notificationCenter
     }
-
-    private func postUpdate() {
-        let update = ParticipantUpdate.didUpdate(participant: self)
-        notificationCenter.post(name: .participantUpdate, object: self, payload: update)
+    
+    private func sendUpdate() {
+        delegate?.didUpdate(participant: self)
     }
 }
 
@@ -158,7 +151,7 @@ extension LocalParticipant: LocalParticipantDelegate {
         participant: TwilioVideo.LocalParticipant,
         networkQualityLevel: NetworkQualityLevel
     ) {
-        postUpdate()
+        sendUpdate()
     }
 }
 

--- a/VideoApp/VideoApp/Video/Participants/Participant.swift
+++ b/VideoApp/VideoApp/Video/Participants/Participant.swift
@@ -19,10 +19,6 @@ import TwilioVideo
 
 typealias NetworkQualityLevel = TwilioVideo.NetworkQualityLevel // So UI doesn't have to import TwilioVideo
 
-enum ParticipantUpdate {
-    case didUpdate(participant: Participant)
-}
-
 protocol Participant: AnyObject, ListDiffable {
     var identity: String { get }
     var cameraTrack: VideoTrack? { get }

--- a/VideoApp/VideoApp/Video/Participants/ParticipantDelegate.swift
+++ b/VideoApp/VideoApp/Video/Participants/ParticipantDelegate.swift
@@ -16,13 +16,6 @@
 
 import Foundation
 
-class LocalParticipantFactory {
-    func makeLocalParticipant() -> LocalParticipant {
-        LocalParticipant(
-            identity: UserStoreFactory().makeUserStore().user.displayName,
-            micTrackFactory: MicTrackFactory(),
-            cameraManagerFactory: CameraManagerFactory(),
-            notificationCenter: .default
-        )
-    }
+protocol ParticipantDelegate: AnyObject {
+    func didUpdate(participant: Participant)
 }

--- a/VideoApp/VideoApp/Video/Participants/RemoteParticipant.swift
+++ b/VideoApp/VideoApp/Video/Participants/RemoteParticipant.swift
@@ -27,23 +27,22 @@ class RemoteParticipant: NSObject, Participant {
         
         return micTrack.isTrackSubscribed && micTrack.isTrackEnabled
     }
-    var isDominantSpeaker = false { didSet { postUpdate() } }
+    var isDominantSpeaker = false
     var isPinned = false
     private(set) var cameraTrack: VideoTrack?
     private(set) var screenTrack: VideoTrack?
     private let participant: TwilioVideo.RemoteParticipant
-    private let notificationCenter: NotificationCenter
-    
-    init(participant: TwilioVideo.RemoteParticipant, notificationCenter: NotificationCenter) {
+    private weak var delegate: ParticipantDelegate?
+
+    init(participant: TwilioVideo.RemoteParticipant, delegate: ParticipantDelegate) {
         self.participant = participant
-        self.notificationCenter = notificationCenter
+        self.delegate = delegate
         super.init()
         participant.delegate = self
     }
     
-    private func postUpdate() {
-        let update = ParticipantUpdate.didUpdate(participant: self)
-        notificationCenter.post(name: .participantUpdate, object: self, payload: update)
+    private func sendUpdate() {
+        delegate?.didUpdate(participant: self)
     }
 }
 
@@ -62,28 +61,28 @@ extension RemoteParticipant: RemoteParticipantDelegate {
         participant: TwilioVideo.RemoteParticipant,
         publication: RemoteVideoTrackPublication
     ) {
-        postUpdate()
+        sendUpdate()
     }
     
     func remoteParticipantDidDisableVideoTrack(
         participant: TwilioVideo.RemoteParticipant,
         publication: RemoteVideoTrackPublication
     ) {
-        postUpdate()
+        sendUpdate()
     }
     
     func remoteParticipantSwitchedOnVideoTrack(
         participant: TwilioVideo.RemoteParticipant,
         track: TwilioVideo.RemoteVideoTrack
     ) {
-        postUpdate()
+        sendUpdate()
     }
 
     func remoteParticipantSwitchedOffVideoTrack(
         participant: TwilioVideo.RemoteParticipant,
         track: TwilioVideo.RemoteVideoTrack
     ) {
-        postUpdate()
+        sendUpdate()
     }
     
     func didSubscribeToVideoTrack(
@@ -98,7 +97,7 @@ extension RemoteParticipant: RemoteParticipantDelegate {
         case .screen: screenTrack = RemoteVideoTrack(track: videoTrack)
         }
         
-        postUpdate()
+        sendUpdate()
     }
     
     func didUnsubscribeFromVideoTrack(
@@ -113,21 +112,21 @@ extension RemoteParticipant: RemoteParticipantDelegate {
         case .screen: screenTrack = nil
         }
         
-        postUpdate()
+        sendUpdate()
     }
     
     func remoteParticipantDidEnableAudioTrack(
         participant: TwilioVideo.RemoteParticipant,
         publication: RemoteAudioTrackPublication
     ) {
-        postUpdate()
+        sendUpdate()
     }
     
     func remoteParticipantDidDisableAudioTrack(
         participant: TwilioVideo.RemoteParticipant,
         publication: RemoteAudioTrackPublication
     ) {
-        postUpdate()
+        sendUpdate()
     }
     
     func didSubscribeToAudioTrack(
@@ -135,7 +134,7 @@ extension RemoteParticipant: RemoteParticipantDelegate {
         publication: RemoteAudioTrackPublication,
         participant: TwilioVideo.RemoteParticipant
     ) {
-        postUpdate()
+        sendUpdate()
     }
     
     func didUnsubscribeFromAudioTrack(
@@ -143,14 +142,14 @@ extension RemoteParticipant: RemoteParticipantDelegate {
         publication: RemoteAudioTrackPublication,
         participant: TwilioVideo.RemoteParticipant
     ) {
-        postUpdate()
+        sendUpdate()
     }
 
     func remoteParticipantNetworkQualityLevelDidChange(
         participant: TwilioVideo.RemoteParticipant,
         networkQualityLevel: NetworkQualityLevel
     ) {
-        postUpdate()
+        sendUpdate()
     }
 }
 

--- a/VideoApp/VideoApp/Video/Room/Room.swift
+++ b/VideoApp/VideoApp/Video/Room/Room.swift
@@ -89,7 +89,7 @@ import TwilioVideo
             old.isPinned = false
         }
         
-        new.isPinned = !new.isPinned
+        new.isPinned.toggle()
         post(.didUpdateParticipants(participants: [old, new].compactMap { $0 }))
     }
     

--- a/VideoApp/VideoApp/Video/Room/Room.swift
+++ b/VideoApp/VideoApp/Video/Room/Room.swift
@@ -24,6 +24,7 @@ import TwilioVideo
         case didDisconnect(error: Error?)
         case didAddRemoteParticipants(participants: [Participant])
         case didRemoveRemoteParticipants(participants: [Participant])
+        case didUpdateParticipants(participants: [Participant])
     }
 
     let localParticipant: LocalParticipant
@@ -47,6 +48,8 @@ import TwilioVideo
         self.connectOptionsFactory = connectOptionsFactory
         self.notificationCenter = notificationCenter
         self.twilioVideoSDKType = twilioVideoSDKType
+        super.init()
+        localParticipant.delegate = self
     }
 
     func connect(roomName: String) {
@@ -78,6 +81,18 @@ import TwilioVideo
         room?.disconnect()
     }
     
+    func togglePin(participant new: Participant) {
+        let allParticipants: [Participant] = [localParticipant] + remoteParticipants
+        let old = allParticipants.first(where: { $0.isPinned })
+        
+        if let old = old, old !== new {
+            old.isPinned = false
+        }
+        
+        new.isPinned = !new.isPinned
+        post(.didUpdateParticipants(participants: [old, new].compactMap { $0 }))
+    }
+    
     private func post(_ update: Update) {
         notificationCenter.post(name: .roomUpdate, object: self, payload: update)
     }
@@ -87,7 +102,7 @@ extension Room: TwilioVideo.RoomDelegate {
     func roomDidConnect(room: TwilioVideo.Room) {
         localParticipant.participant = room.localParticipant
         remoteParticipants = room.remoteParticipants.map {
-            RemoteParticipant(participant: $0, notificationCenter: notificationCenter)
+            RemoteParticipant(participant: $0, delegate: self)
         }
         state = .connected
         post(.didConnect)
@@ -115,7 +130,7 @@ extension Room: TwilioVideo.RoomDelegate {
     }
     
     func participantDidConnect(room: TwilioVideo.Room, participant: TwilioVideo.RemoteParticipant) {
-        remoteParticipants.append(RemoteParticipant(participant: participant, notificationCenter: notificationCenter))
+        remoteParticipants.append(RemoteParticipant(participant: participant, delegate: self))
     
         post(.didAddRemoteParticipants(participants: [remoteParticipants.last!]))
     }
@@ -127,9 +142,17 @@ extension Room: TwilioVideo.RoomDelegate {
     }
     
     func dominantSpeakerDidChange(room: TwilioVideo.Room, participant: TwilioVideo.RemoteParticipant?) {
-        guard let participant = remoteParticipants.first(where: { $0.identity == participant?.identity }) else { return }
+        guard let new = remoteParticipants.first(where: { $0.identity == participant?.identity }) else { return }
 
-        remoteParticipants.first(where: { $0.isDominantSpeaker })?.isDominantSpeaker = false
-        participant.isDominantSpeaker = true // The participant sends out update
+        let old = remoteParticipants.first(where: { $0.isDominantSpeaker })
+        old?.isDominantSpeaker = false
+        new.isDominantSpeaker = true
+        post(.didUpdateParticipants(participants: [old, new].compactMap { $0 }))
+    }
+}
+
+extension Room: ParticipantDelegate {
+    func didUpdate(participant: Participant) {
+        post(.didUpdateParticipants(participants: [participant]))
     }
 }

--- a/VideoApp/VideoApp/Video/Room/RoomFactory.swift
+++ b/VideoApp/VideoApp/Video/Room/RoomFactory.swift
@@ -17,8 +17,13 @@
 import TwilioVideo
 
 class RoomFactory {
-    func makeRoom(localParticipant: LocalParticipant) -> Room {
-        Room(
+    func makeRoom() -> Room {
+        let localParticipant = LocalParticipant(
+            identity: UserStoreFactory().makeUserStore().user.displayName,
+            micTrackFactory: MicTrackFactory(),
+            cameraManagerFactory: CameraManagerFactory()
+        )
+        return Room(
             localParticipant: localParticipant,
             accessTokenStore: TwilioAccessTokenStoreFactory().makeTwilioAccessTokenStore(),
             connectOptionsFactory: ConnectOptionsFactory(),

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
@@ -82,7 +82,7 @@ class RoomViewModel {
     }
     
     func togglePin(at index: Int) {
-        participantsStore.togglePin(at: index)
+        room.togglePin(participant: participantsStore.participants[index])
     }
 
     @objc private func handleRoomUpdate(_ notification: Notification) {
@@ -92,7 +92,7 @@ class RoomViewModel {
         case .didStartConnecting, .didConnect: delegate?.didConnect()
         case let .didFailToConnect(error): delegate?.didFailToConnect(error: error)
         case let .didDisconnect(error): delegate?.didDisconnect(error: error)
-        case .didAddRemoteParticipants, .didRemoveRemoteParticipants: break
+        case .didAddRemoteParticipants, .didRemoveRemoteParticipants, .didUpdateParticipants: break
         }
     }
 


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-708

#### The Problem

Pinning a participant can modify multiple participants. When a participant is modified we immediately broadcast the update. And so what was happening was participant A would get updated (causing track priority changes) and then participant B would get updated (causing more track priority changes). The end result was correct but we were updating priorities more than necessary which is confusing and inefficient.

Dominant speaker can also cause updates to multiple participants but probably was not a problem because we let the server manage priority for that. However it is a concern because it is a fragile interface.

#### The Solution

We need to batch participant updates together so that we only change track priorities once, after all participant updates are applied.

1. Instead of participant updates coming from both `Room` (add, remove) and `Participant` (update) they all come from `Room` now. This allows us to modify multiple participants and then broadcast an update and not have any incomplete state. I think it is more conventional also. It more closely models popular update interfaces like `ListDiff`. So I think this is generally better and it got rid of some awkward stuff. And it is one less notification to deal with.
1. `Room` now handles pin logic because pin state is on `Participant` and `Room` needs to broadcast updates. This kind of bends the rules of the SDK integration layer because pin is really unrelated to the SDK but I think it is better than moving pin state out of `Participant`.
1. `LobbyViewController` now creates a `Room` instead of `LocalParticipant` because it needs to get participant updates from `Room`. This didn't really have much of an impact. Maybe in some ways it's better.