### PR TITLE
AHOYAPPS-727: Fix slow camera resume

### DIFF
--- a/VideoApp/VideoApp/Video/Participants/LocalParticipant.swift
+++ b/VideoApp/VideoApp/Video/Participants/LocalParticipant.swift
@@ -159,10 +159,12 @@ extension LocalParticipant: CameraManagerDelegate {
     func trackSourceWasInterrupted(track: LocalVideoTrack) {
         // Disable instead of unpublish to work around SDK bug https://issues.corp.twilio.com/browse/AHOYAPPS-701
         track.track.isEnabled = false
+        sendUpdate()
     }
     
     func trackSourceInterruptionEnded(track: LocalVideoTrack) {
         track.track.isEnabled = true
+        sendUpdate()
     }
 }
 


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-727

Views that display camera video were not immediately updated for source interruption events. So on the room screen it took a couple seconds for the camera video to resume after the app returned to the foreground. Much more responsive now with the fix.