### PR TITLE
AHOYAPPS-805: Longer passcode format

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The passcode will expire after one week. Follow the steps below to sign in with 
 1. In the app tap `Settings > Sign Out`.
 1. Repeat the [steps above](#start-video-conference).
 
+⚠️ Changes were made to the Twilio Access Token Server and the app to support a new passcode format. Using old source code from this repo with a new Twilio Access Token Server may produce an error when the user enters the passcode in the app. The app will display this message: `An error occurred. Please try again.`. To fix the problem rebuild the app with the latest source code from this repo.
+
 ## Tests
 
 ### Unit Tests

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ The app requires a back-end to generate [Twilio access tokens](https://www.twili
 
 The passcode will expire after one week. To generate a new passcode, run `twilio rtc:apps:video:deploy --authentication passcode --override`.
 
-#### Troubleshooting The Twilio CLI
+#### Troubleshooting
 
-If any errors occur after running a [Twilio CLI RTC Plugin](https://github.com/twilio-labs/plugin-rtc) command, then try the following steps.
+If any errors occur after running a [Twilio CLI RTC Plugin](https://github.com/twilio-labs/plugin-rtc) command, or the application fails to validate a passcode, then try the following steps.
 
-1. Run `twilio plugins:update` to update the rtc plugin to the latest version.
+1. Update your application to the latest source
+1. Run `twilio plugins:update` to update the RTC plugin to the latest version.
 1. Run `twilio rtc:apps:video:delete` to delete any existing authentication servers.
 1. Run `twilio rtc:apps:video:deploy --authentication passcode` to deploy a new authentication server.
 
@@ -80,8 +81,6 @@ The passcode will expire after one week. Follow the steps below to sign in with 
 1. [Generate a new passcode](#deploy-twilio-access-token-server).
 1. In the app tap `Settings > Sign Out`.
 1. Repeat the [steps above](#start-video-conference).
-
-⚠️ Changes were made to the Twilio Access Token Server and the app to support a new passcode format. Using old source code from this repo with a new Twilio Access Token Server may produce an error when the user enters the passcode in the app. The app will display this message: `An error occurred. Please try again.`. To fix the problem rebuild the app with the latest source code from this repo.
 
 ## Tests
 

--- a/VideoApp/Video-InternalTests/Specs/CommunityAuthStoreSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/CommunityAuthStoreSpec.swift
@@ -128,7 +128,7 @@ class CommunityAuthStoreSpec: QuickSpec {
             
             func signIn(
                 userIdentity: String = "",
-                passcode: String = "",
+                passcode: String = "12546985321456",
                 apiResult: Result<Any, APIError> = .success(CommunityCreateTwilioAccessTokenResponse.stub())
             ) {
                 mockAPI.stubbedRequestCompletionResult = apiResult
@@ -157,6 +157,18 @@ class CommunityAuthStoreSpec: QuickSpec {
                             
                             expect(mockAPI.invokedConfigSetterCount).to(equal(1))
                             expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-1749-dev.twil.io")))
+                        }
+                    }
+                }
+                
+                context("when passcode is invalid format") {
+                    context("when passcode is empty string") {
+                        it("calls completion with passcodeIncorrect error") {
+                            signIn(passcode: "")
+
+                            expect(invokedCompletionCount).to(equal(1))
+                            expect(invokedCompletionParameters?.error).to(equal(.passcodeIncorrect))
+                            expect(mockAPI.invokedRequestCount).to(equal(0))
                         }
                     }
                 }
@@ -208,21 +220,21 @@ class CommunityAuthStoreSpec: QuickSpec {
                 }
 
                 context("when result is success") {
-                    context("when passcode is foo") {
-                        it("stores foo passcode in keychain") {
-                            signIn(passcode: "foo", apiResult: .success(CommunityCreateTwilioAccessTokenResponse.stub()))
+                    context("when passcode is 21564852315698") {
+                        it("stores 21564852315698 passcode in keychain") {
+                            signIn(passcode: "21564852315698", apiResult: .success(CommunityCreateTwilioAccessTokenResponse.stub()))
                             
                             expect(mockKeychainStore.invokedPasscodeSetterCount).to(equal(1))
-                            expect(mockKeychainStore.invokedPasscode).to(equal("foo"))
+                            expect(mockKeychainStore.invokedPasscode).to(equal("21564852315698"))
                         }
                     }
 
-                    context("when passcode is bar") {
-                        it("stores bar passcode in keychain") {
-                            signIn(passcode: "bar", apiResult: .success(CommunityCreateTwilioAccessTokenResponse.stub()))
+                    context("when passcode is 65984128742143") {
+                        it("stores 65984128742143 passcode in keychain") {
+                            signIn(passcode: "65984128742143", apiResult: .success(CommunityCreateTwilioAccessTokenResponse.stub()))
                             
                             expect(mockKeychainStore.invokedPasscodeSetterCount).to(equal(1))
-                            expect(mockKeychainStore.invokedPasscode).to(equal("bar"))
+                            expect(mockKeychainStore.invokedPasscode).to(equal("65984128742143"))
                         }
                     }
 

--- a/VideoApp/Video-InternalTests/Specs/CommunityAuthStoreSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/CommunityAuthStoreSpec.swift
@@ -105,18 +105,18 @@ class CommunityAuthStoreSpec: QuickSpec {
                 }
             }
 
-            context("when passcode is 2546985235") {
-                it("configures API with video-app-5235-dev.twil.io host") {
-                    mockKeychainStore.stubbedPasscode = "2546985235"
+            context("when passcode is 25469852355647") {
+                it("configures API with video-app-5235-5647-dev.twil.io host") {
+                    mockKeychainStore.stubbedPasscode = "25469852355647"
                     
                     sut.start()
                     
                     expect(mockAPI.invokedConfigSetterCount).to(equal(1))
-                    expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-5235-dev.twil.io")))
+                    expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-5235-5647-dev.twil.io")))
                 }
             }
         }
-        
+
         describe("signIn with userIdentity and passcode") {
             var invokedCompletionCount = 0
             var invokedCompletionParameters: (error: AuthError?, Void)?
@@ -139,21 +139,25 @@ class CommunityAuthStoreSpec: QuickSpec {
             }
             
             describe("configureAPI") {
-                context("when passcode is 2546985235") {
-                    it("configures API with video-app-5235-dev.twil.io host") {
-                        signIn(passcode: "2546985235")
-                        
-                        expect(mockAPI.invokedConfigSetterCount).to(equal(1))
-                        expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-5235-dev.twil.io")))
+                context("when passcode is new format") {
+                    context("when passcode is 25469852355627") {
+                        it("configures API with video-app-5235-5627-dev.twil.io host") {
+                            signIn(passcode: "25469852355627")
+                            
+                            expect(mockAPI.invokedConfigSetterCount).to(equal(1))
+                            expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-5235-5627-dev.twil.io")))
+                        }
                     }
                 }
-
-                context("when passcode is 6548521749") {
-                    it("configures API with video-app-1749-dev.twil.io host") {
-                        signIn(passcode: "6548521749")
-                        
-                        expect(mockAPI.invokedConfigSetterCount).to(equal(1))
-                        expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-1749-dev.twil.io")))
+                
+                context("when passcode is old format") {
+                    context("when passcode is 6548521749") {
+                        it("configures API with video-app-1749-dev.twil.io host") {
+                            signIn(passcode: "6548521749")
+                            
+                            expect(mockAPI.invokedConfigSetterCount).to(equal(1))
+                            expect(mockAPI.invokedConfig).to(equal(APIConfig(host: "video-app-1749-dev.twil.io")))
+                        }
                     }
                 }
             }
@@ -181,19 +185,19 @@ class CommunityAuthStoreSpec: QuickSpec {
                     }
                 }
 
-                context("when passcode is foo") {
-                    it("is called with foo passcode") {
-                        signIn(passcode: "foo")
+                context("when passcode is 15648298735694") {
+                    it("is called with 15648298735694 passcode") {
+                        signIn(passcode: "15648298735694")
                         
-                        expect((mockAPI.invokedRequestParameters?.request as? CommunityCreateTwilioAccessTokenRequest)?.parameters.passcode).to(equal("foo"))
+                        expect((mockAPI.invokedRequestParameters?.request as? CommunityCreateTwilioAccessTokenRequest)?.parameters.passcode).to(equal("15648298735694"))
                     }
                 }
 
-                context("when passcode is bar") {
-                    it("is called with bar passcode") {
-                        signIn(passcode: "bar")
+                context("when passcode is 56487269813982") {
+                    it("is called with 56487269813982 passcode") {
+                        signIn(passcode: "56487269813982")
                         
-                        expect((mockAPI.invokedRequestParameters?.request as? CommunityCreateTwilioAccessTokenRequest)?.parameters.passcode).to(equal("bar"))
+                        expect((mockAPI.invokedRequestParameters?.request as? CommunityCreateTwilioAccessTokenRequest)?.parameters.passcode).to(equal("56487269813982"))
                     }
                 }
 

--- a/VideoApp/Video-InternalTests/Specs/CommunityTwilioAccessTokenStoreSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/CommunityTwilioAccessTokenStoreSpec.swift
@@ -76,11 +76,11 @@ class CommunityTwilioAccessTokenStoreSpec: QuickSpec {
                     }
                 }
 
-                context("when passcode is foo") {
-                    it("is called with foo passcode") {
-                        fetchTwilioAccessToken(passcode: "foo")
+                context("when passcode is 59842367125687") {
+                    it("is called with 59842367125687 passcode") {
+                        fetchTwilioAccessToken(passcode: "59842367125687")
                         
-                        expect((mockAPI.invokedRequestParameters?.request as? CommunityCreateTwilioAccessTokenRequest)?.parameters.passcode).to(equal("foo"))
+                        expect((mockAPI.invokedRequestParameters?.request as? CommunityCreateTwilioAccessTokenRequest)?.parameters.passcode).to(equal("59842367125687"))
                     }
                 }
 

--- a/VideoApp/Video-InternalTests/Specs/PasscodeComponentsSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/PasscodeComponentsSpec.swift
@@ -21,43 +21,43 @@ import Quick
 
 class PasscodeComponentsSpec: QuickSpec {
     override func spec() {
-        var sut: PasscodeComponents!
+        var sut: PasscodeComponents?
         
         describe("init") {
             context("when string is new format") {
                 context("when string length is 14") {
                     beforeEach {
-                        sut = PasscodeComponents(string: "65897412385467")
+                        sut = try? PasscodeComponents(string: "65897412385467")
                     }
                     
                     it("sets passcode to entire string") {
-                        expect(sut.passcode).to(equal("65897412385467"))
+                        expect(sut?.passcode).to(equal("65897412385467"))
                     }
 
                     it("sets appID to characters at indices 6 to 9") {
-                        expect(sut.appID).to(equal("1238"))
+                        expect(sut?.appID).to(equal("1238"))
                     }
                     
                     it("sets serverlessID to last 4 characters") {
-                        expect(sut.serverlessID).to(equal("5467"))
+                        expect(sut?.serverlessID).to(equal("5467"))
                     }
                 }
                 
                 context("when string length is 20") {
                     beforeEach {
-                        sut = PasscodeComponents(string: "59846823174859632894")
+                        sut = try? PasscodeComponents(string: "59846823174859632894")
                     }
                     
                     it("sets passcode to entire string") {
-                        expect(sut.passcode).to(equal("59846823174859632894"))
+                        expect(sut?.passcode).to(equal("59846823174859632894"))
                     }
 
                     it("sets appID to characters at indices 6 to 9") {
-                        expect(sut.appID).to(equal("2317"))
+                        expect(sut?.appID).to(equal("2317"))
                     }
                     
                     it("sets serverlessID to last 10 characters") {
-                        expect(sut.serverlessID).to(equal("4859632894"))
+                        expect(sut?.serverlessID).to(equal("4859632894"))
                     }
                 }
             }
@@ -65,37 +65,37 @@ class PasscodeComponentsSpec: QuickSpec {
             context("when string is old format") {
                 context("when string length is 10") {
                     beforeEach {
-                        sut = PasscodeComponents(string: "5987462314")
+                        sut = try? PasscodeComponents(string: "5987462314")
                     }
                     
                     it("sets passcode to entire string") {
-                        expect(sut.passcode).to(equal("5987462314"))
+                        expect(sut?.passcode).to(equal("5987462314"))
                     }
 
                     it("sets appID to nil") {
-                        expect(sut.appID).to(beNil())
+                        expect(sut?.appID).to(beNil())
                     }
                     
                     it("sets serverlessID to last 4 characters") {
-                        expect(sut.serverlessID).to(equal("2314"))
+                        expect(sut?.serverlessID).to(equal("2314"))
                     }
                 }
                 
                 context("when string length is 13") {
                     beforeEach {
-                        sut = PasscodeComponents(string: "9874652871365")
+                        sut = try? PasscodeComponents(string: "9874652871365")
                     }
                     
                     it("sets passcode to entire string") {
-                        expect(sut.passcode).to(equal("9874652871365"))
+                        expect(sut?.passcode).to(equal("9874652871365"))
                     }
 
                     it("sets appID to nil") {
-                        expect(sut.appID).to(beNil())
+                        expect(sut?.appID).to(beNil())
                     }
 
                     it("sets serverlessID to last 7 characters") {
-                        expect(sut.serverlessID).to(equal("2871365"))
+                        expect(sut?.serverlessID).to(equal("2871365"))
                     }
                 }
 
@@ -103,8 +103,8 @@ class PasscodeComponentsSpec: QuickSpec {
             
             context("when string is invalid") {
                 context("when string length is 6") {
-                    it("returns nil") {
-                        expect(PasscodeComponents(string: "256984")).to(beNil())
+                    it("throws passcodeIncorrect error") {
+                        expect { try PasscodeComponents(string: "256984") }.to(throwError(AuthError.passcodeIncorrect))
                     }
                 }
             }

--- a/VideoApp/Video-InternalTests/Specs/PasscodeComponentsSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/PasscodeComponentsSpec.swift
@@ -24,31 +24,88 @@ class PasscodeComponentsSpec: QuickSpec {
         var sut: PasscodeComponents!
         
         describe("init") {
-            context("when string is 10 characters") {
-                beforeEach {
-                    sut = PasscodeComponents(string: "2546985627")
+            context("when string is new format") {
+                context("when string length is 14") {
+                    beforeEach {
+                        sut = PasscodeComponents(string: "65897412385467")
+                    }
+                    
+                    it("sets passcode to entire string") {
+                        expect(sut.passcode).to(equal("65897412385467"))
+                    }
+
+                    it("sets appID to characters at indices 6 to 9") {
+                        expect(sut.appID).to(equal("1238"))
+                    }
+                    
+                    it("sets serverlessID to last 4 characters") {
+                        expect(sut.serverlessID).to(equal("5467"))
+                    }
                 }
                 
-                it("sets passcode to entire string") {
-                    expect(sut.passcode).to(equal("2546985627"))
-                }
-                
-                it("sets appID to last 4 characters") {
-                    expect(sut.appID).to(equal("5627"))
+                context("when string length is 20") {
+                    beforeEach {
+                        sut = PasscodeComponents(string: "59846823174859632894")
+                    }
+                    
+                    it("sets passcode to entire string") {
+                        expect(sut.passcode).to(equal("59846823174859632894"))
+                    }
+
+                    it("sets appID to characters at indices 6 to 9") {
+                        expect(sut.appID).to(equal("2317"))
+                    }
+                    
+                    it("sets serverlessID to last 10 characters") {
+                        expect(sut.serverlessID).to(equal("4859632894"))
+                    }
                 }
             }
             
-            context("when string is 11 characters") {
-                beforeEach {
-                    sut = PasscodeComponents(string: "65874258516")
+            context("when string is old format") {
+                context("when string length is 10") {
+                    beforeEach {
+                        sut = PasscodeComponents(string: "5987462314")
+                    }
+                    
+                    it("sets passcode to entire string") {
+                        expect(sut.passcode).to(equal("5987462314"))
+                    }
+
+                    it("sets appID to nil") {
+                        expect(sut.appID).to(beNil())
+                    }
+                    
+                    it("sets serverlessID to last 4 characters") {
+                        expect(sut.serverlessID).to(equal("2314"))
+                    }
                 }
                 
-                it("sets passcode to entire string") {
-                    expect(sut.passcode).to(equal("65874258516"))
+                context("when string length is 13") {
+                    beforeEach {
+                        sut = PasscodeComponents(string: "9874652871365")
+                    }
+                    
+                    it("sets passcode to entire string") {
+                        expect(sut.passcode).to(equal("9874652871365"))
+                    }
+
+                    it("sets appID to nil") {
+                        expect(sut.appID).to(beNil())
+                    }
+
+                    it("sets serverlessID to last 7 characters") {
+                        expect(sut.serverlessID).to(equal("2871365"))
+                    }
                 }
-                
-                it("sets appID to last 5 characters") {
-                    expect(sut.appID).to(equal("58516"))
+
+            }
+            
+            context("when string is invalid") {
+                context("when string length is 6") {
+                    it("returns nil") {
+                        expect(PasscodeComponents(string: "256984")).to(beNil())
+                    }
                 }
             }
         }

--- a/VideoApp/VideoApp/API/Requests/CommunityCreateTwilioAccessTokenRequest.swift
+++ b/VideoApp/VideoApp/API/Requests/CommunityCreateTwilioAccessTokenRequest.swift
@@ -30,7 +30,7 @@ struct CommunityCreateTwilioAccessTokenRequest: APIRequest {
 
     init(passcode: String, userIdentity: String, roomName: String) {
         parameters = Parameters(
-            passcode: PasscodeComponents(string: passcode)?.passcode ?? "",
+            passcode: (try? PasscodeComponents(string: passcode))?.passcode ?? "",
             userIdentity: userIdentity,
             roomName: roomName
         )

--- a/VideoApp/VideoApp/API/Requests/CommunityCreateTwilioAccessTokenRequest.swift
+++ b/VideoApp/VideoApp/API/Requests/CommunityCreateTwilioAccessTokenRequest.swift
@@ -30,7 +30,7 @@ struct CommunityCreateTwilioAccessTokenRequest: APIRequest {
 
     init(passcode: String, userIdentity: String, roomName: String) {
         parameters = Parameters(
-            passcode: PasscodeComponents(string: passcode).passcode,
+            passcode: PasscodeComponents(string: passcode)?.passcode ?? "",
             userIdentity: userIdentity,
             roomName: roomName
         )

--- a/VideoApp/VideoApp/Stores/Auth/CommunityAuthStore.swift
+++ b/VideoApp/VideoApp/Stores/Auth/CommunityAuthStore.swift
@@ -38,7 +38,7 @@ class CommunityAuthStore: AuthStoreWriting {
     func start() {
         guard let passcode = keychainStore.passcode else { return }
         
-        configureAPI(passcode: passcode)
+        try? configureAPI(passcode: passcode)
     }
 
     func signIn(email: String, password: String, completion: @escaping (AuthError?) -> Void) {
@@ -46,7 +46,8 @@ class CommunityAuthStore: AuthStoreWriting {
     }
 
     func signIn(userIdentity: String, passcode: String, completion: @escaping (AuthError?) -> Void) {
-        configureAPI(passcode: passcode)
+        guard (try? configureAPI(passcode: passcode)) != nil else { completion(.passcodeIncorrect); return }
+
         let request = CommunityCreateTwilioAccessTokenRequest(passcode: passcode, userIdentity: userIdentity, roomName: "")
         
         api.request(request) { [weak self] result in
@@ -79,8 +80,8 @@ class CommunityAuthStore: AuthStoreWriting {
         fatalError("Refresh ID token not supported by community auth.")
     }
     
-    private func configureAPI(passcode: String) {
-        guard let passcodeComponents = PasscodeComponents(string: passcode) else { return }
+    private func configureAPI(passcode: String) throws {
+        let passcodeComponents = try PasscodeComponents(string: passcode)
         
         var appID: String {
             guard let appID = passcodeComponents.appID else { return "" }

--- a/VideoApp/VideoApp/Stores/Auth/CommunityAuthStore.swift
+++ b/VideoApp/VideoApp/Stores/Auth/CommunityAuthStore.swift
@@ -80,7 +80,15 @@ class CommunityAuthStore: AuthStoreWriting {
     }
     
     private func configureAPI(passcode: String) {
-        let host = "video-app-\(PasscodeComponents(string: passcode).appID)-dev.twil.io"
+        guard let passcodeComponents = PasscodeComponents(string: passcode) else { return }
+        
+        var appID: String {
+            guard let appID = passcodeComponents.appID else { return "" }
+            
+            return "\(appID)-"
+        }
+        
+        let host = "video-app-\(appID)\(passcodeComponents.serverlessID)-dev.twil.io"
         api.config = APIConfig(host: host)
     }
 }

--- a/VideoApp/VideoApp/Stores/Auth/PasscodeComponents.swift
+++ b/VideoApp/VideoApp/Stores/Auth/PasscodeComponents.swift
@@ -21,7 +21,7 @@ struct PasscodeComponents {
     let appID: String?
     let serverlessID: String
     
-    init?(string: String) {
+    init(string: String) throws {
         passcode = string
         let shortPasscodeLength = 6
         let appIDLength = 4
@@ -40,7 +40,7 @@ struct PasscodeComponents {
             let serverlessIDStartIndex = string.index(string.startIndex, offsetBy: shortPasscodeLength)
             serverlessID = String(string[serverlessIDStartIndex...])
         } else {
-            return nil
+            throw AuthError.passcodeIncorrect
         }
     }
 }

--- a/VideoApp/VideoApp/Stores/Auth/PasscodeComponents.swift
+++ b/VideoApp/VideoApp/Stores/Auth/PasscodeComponents.swift
@@ -18,10 +18,29 @@ import Foundation
 
 struct PasscodeComponents {
     let passcode: String
-    let appID: String
+    let appID: String?
+    let serverlessID: String
     
-    init(string: String) {
+    init?(string: String) {
         passcode = string
-        appID = String(string.dropFirst(6))
+        let shortPasscodeLength = 6
+        let appIDLength = 4
+        let serverlessIDMinLength = 4
+        let newFormatMinLength = shortPasscodeLength + appIDLength + serverlessIDMinLength
+        let oldFormatMinLength = shortPasscodeLength + serverlessIDMinLength
+
+        if string.count >= newFormatMinLength {
+            let appIDStartIndex = string.index(string.startIndex, offsetBy: shortPasscodeLength)
+            let appIDEndIndex = string.index(appIDStartIndex, offsetBy: appIDLength - 1)
+            appID = String(string[appIDStartIndex...appIDEndIndex])
+            let serverlessIDStartIndex = string.index(after: appIDEndIndex)
+            serverlessID = String(string[serverlessIDStartIndex...])
+        } else if string.count >= oldFormatMinLength {
+            appID = nil
+            let serverlessIDStartIndex = string.index(string.startIndex, offsetBy: shortPasscodeLength)
+            serverlessID = String(string[serverlessIDStartIndex...])
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-805

### ⚠️ This change is required for compatibility with updated [token server](https://github.com/twilio/twilio-video-app-ios#deploy-twilio-access-token-server)

1. Add support for longer passcode format. The old format only used 4 digits to generate the URL which was not unique enough and some customers were running into conflicts. The only difference from an end user perspective is the passcode is now 14 digits instead of 10.
1. This is still backwards compatible with the shorter passcode format.
1. Using the latest [token server](https://github.com/twilio/twilio-video-app-ios#deploy-twilio-access-token-server) with old iOS software will produce an error when the user enters the passcode. The solution is to update iOS software to include changes in this PR.