### PR TITLE
AHOYAPPS-833: Change tag format

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,9 +33,9 @@ platform :ios do
 
   lane :beta do
     ensure_git_status_clean
-    increment_build_number(xcodeproj: "VideoApp/VideoApp.xcodeproj")
+    build_number = increment_build_number(xcodeproj: "VideoApp/VideoApp.xcodeproj")
     commit_version_bump(message: "Increment build number [skip ci]", xcodeproj: "VideoApp/VideoApp.xcodeproj")
-    add_git_tag
+    add_git_tag(tag: "v0.#{build_number}")
     push_to_git_remote
 
     gym(


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-833

Change tag format from `builds/iosbeta/61` to `v0.61`.

I tested locally.