### PR TITLE
Implement Go Room Type Support

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -157,8 +157,8 @@ SPEC CHECKSUMS:
   Alamofire: 3ba7a4db18b4f62c4a1c0e1cb39d7f3d52e10ada
   AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
   AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
-  Crashlytics: 540b7e5f5da5a042647227a5e3ac51d85eed06df
-  Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
+  Crashlytics: 9220f5bc89e7a618df411b4f639389dbfb0e03d2
+  Fabric: ea977e3cd9c20425516d3dafd3bf8c941c51223f
   Firebase: 0219bb4782eb1406f1b9b0628a2e625484ce910d
   FirebaseAnalytics: f68b9f3f1241385129ae0a83b63627fc420c05e5
   FirebaseAuth: 831577b184ecaba38bc886768c1c22a450cc44e3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This app is a sample video conferencing app that uses the [Twilio Programmable Video SDK](https://www.twilio.com/docs/video/ios). The open source app can be easily configured by developers to try out real-time video and audio features. 
 
-![video-app-screenshots](https://user-images.githubusercontent.com/1930363/76462720-c2f8e080-63a7-11ea-9b15-d4326636c42c.png)
+![App Preview](https://user-images.githubusercontent.com/12685223/94631109-cfca1c80-0284-11eb-8b72-c97276cf34e4.png)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,19 @@ If any errors occur after running a [Twilio CLI RTC Plugin](https://github.com/t
 1. Run `twilio rtc:apps:video:delete` to delete any existing authentication servers.
 1. Run `twilio rtc:apps:video:deploy --authentication passcode` to deploy a new authentication server.
 
-## App Behavior with Different Room Types
+#### App Behavior with Different Room Types
 
-After running the command [to deploy a Twilio Access Token Server](https://github.com/twilio/twilio-video-app-android#deploy-twilio-access-token-server), the room type will be returned in the command line output. Each room type provides a different video experience. More details about these room types can be found [here](https://www.twilio.com/docs/video/tutorials/understanding-video-rooms). The rest of this section explains how these room types affect the behavior of the video app.
+**NOTE:** Usage charges will apply for most room types. See [pricing](https://www.twilio.com/video/pricing) for more information.
+
+After running the command [to deploy a Twilio Access Token Server](#deploy-twilio-access-token-server), the room type will be returned in the command line output. Each room type provides a different video experience. More details about these room types can be found [here](https://www.twilio.com/docs/video/tutorials/understanding-video-rooms). The rest of this section explains how these room types affect the behavior of the video app.
 
 *Group* - The Group room type allows up to fifty participants to join a video room in the app. The Network Quality Level (NQL) indicators and dominant speaker are demonstrated with this room type. Also, the VP8 video codec with simulcast enabled along with a bandwidth profile are set by default in order to provide an optimal group video app experience.
 
 *Small Group* - The Small Group room type provides an identical group video app experience except for a smaller limit of four participants.
 
 *Peer-to-peer* - Although up to ten participants can join a room using the Peer-to-peer (P2P) room type, it is ideal for a one to one video experience. The NQL indicators, bandwidth profiles, and dominant speaker cannot be used with this room type. Thus, they are not demonstrated in the video app. Also, the VP8 video codec with simulcast disabled and 720p minimum video capturing dimensions are also set by default in order to provide an optimal one to one video app experience. If more than ten participants join a room with this room type, then the video app will present an error.
+
+*Go* - The Go room type provides a similar Peer-to-peer video app experience except for a smaller limit of two participants. If more than two participants join a room with this room type, then the video app will present an error.
 
 If the max number of participants is exceeded, then the video app will present an error for all room types.
 

--- a/VideoApp/Video-InternalTests/Specs/RemoteConfigStoreSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/RemoteConfigStoreSpec.swift
@@ -127,6 +127,15 @@ class RemoteConfigStoreSpec: QuickSpec {
                             expect(mockAppSettingsStore.invokedRemoteRoomType).to(equal(.peerToPeer))
                         }
                     }
+
+                    context("when newValue is go") {
+                        it("sets videoCodec setting to vp8") {
+                            sut.roomType = .go
+
+                            expect(mockAppSettingsStore.invokedVideoCodec).to(equal(.vp8))
+                            expect(mockAppSettingsStore.invokedRemoteRoomType).to(equal(.go))
+                        }
+                    }
                 }
                 
                 context("when newValue is not different from setting") {

--- a/VideoApp/VideoApp/API/Responses/CommunityCreateTwilioAccessTokenResponse.swift
+++ b/VideoApp/VideoApp/API/Responses/CommunityCreateTwilioAccessTokenResponse.swift
@@ -18,6 +18,7 @@ import Foundation
 
 struct CommunityCreateTwilioAccessTokenResponse: Decodable {
     enum RoomType: String, Codable { // Codable because it's persisted to track changes
+        case go = "go"
         case group
         case groupSmall = "group-small"
         case peerToPeer = "peer-to-peer"

--- a/VideoApp/VideoApp/Stores/RemoteConfig/RemoteConfigStore.swift
+++ b/VideoApp/VideoApp/Stores/RemoteConfig/RemoteConfigStore.swift
@@ -55,7 +55,7 @@ class RemoteConfigStore: RemoteConfigStoreWriting {
             switch newValue {
             case .group, .groupSmall, .unknown:
                 appSettingsStore.videoCodec = .vp8SimulcastVGA
-            case .peerToPeer:
+            case .peerToPeer, .go:
                 appSettingsStore.videoCodec = .vp8
             }
 

--- a/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
+++ b/VideoApp/VideoApp/Video/Tracks/Camera/CameraConfigFactory.swift
@@ -32,7 +32,7 @@ class CameraConfigFactory {
             let hdDimensions = CMVideoDimensions(width: 900, height: 720)
             
             switch remoteConfigStore.roomType {
-            case .peerToPeer: return hdDimensions
+            case .peerToPeer, .go: return hdDimensions
             case .group, .groupSmall, .unknown: break
             }
             

--- a/VideoApp/VideoApp/Video/Tracks/Camera/CameraSourceFactory.swift
+++ b/VideoApp/VideoApp/Video/Tracks/Camera/CameraSourceFactory.swift
@@ -17,7 +17,7 @@
 import TwilioVideo
 
 class CameraSourceFactory {
-    private let appSettingsStore: AppSettingsStoreWriting = AppSettingsStore.shared
+    private let remoteConfigStore: RemoteConfigStoreReading = RemoteConfigStoreFactory().makeRemoteConfigStore()
     
     func makeCameraSource() -> CameraSource? {
         let options = CameraSourceOptions() { builder in
@@ -25,11 +25,11 @@ class CameraSourceFactory {
                 builder.orientationTracker = UserInterfaceTracker(scene: UIApplication.shared.keyWindow!.windowScene!)
             }
             
-            switch self.appSettingsStore.topology {
-            case .group:
+            switch self.remoteConfigStore.roomType {
+            case .group, .groupSmall:
                 // Take a best guess and remove rotation tags using hardware acceleration
                 builder.rotationTags = .remove
-            case .peerToPeer:
+            case .peerToPeer, .go, .unknown:
                 break
             }
         }


### PR DESCRIPTION
This PR contains support for the Programmable Video Go room type. The Go room type provides a similar peer-to-peer video app experience except for a smaller limit of two participants. If more than two participants join a room with this room type, then the video app will present an error. To learn more about Go, please visit [the Twilio blog](https://www.twilio.com/blog/announcing-twilio-video-webrtc-go).