### PR TITLE
Fix import FirebaseCrashlytics

### DIFF
--- a/VideoApp/VideoApp/Stores/CrashReport/CrashReportStore.swift
+++ b/VideoApp/VideoApp/Stores/CrashReport/CrashReportStore.swift
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-import FirebaseCrashlytics
+import Foundation
 
 protocol CrashReportStoreWriting: LaunchStore {
     func crash()


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Firebase Crashlytics was not used in this file, so I changed it to Foundation.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
