### PR TITLE
Enable UI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ workflows:
           filters: *test_filters
       - test_internal_app:
           filters: *test_filters
-      # - run_ui_tests:
-      #     filters: *test_filters
+      - run_ui_tests:
+          filters: *test_filters
       - deploy_internal_app_beta:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
 executors:
   macos_executor:
     macos:
-      xcode: "12.0.1"
+      xcode: "12.4.0"
 
 commands:
   setup:

--- a/VideoApp/Video-InternalUITests/Helpers/BasicTestCase.swift
+++ b/VideoApp/Video-InternalUITests/Helpers/BasicTestCase.swift
@@ -22,7 +22,7 @@ let app = XCUIApplication()
 class BasicTestCase: XCTestCase {
     override func setUp() {
         continueAfterFailure = false
-        Nimble.AsyncDefaults.timeout = .seconds(5)
+        Nimble.AsyncDefaults.timeout = .seconds(30)
         app.launch()
     }
 }


### PR DESCRIPTION
Enable UI tests again since video SDK fixed a `VideoView` simulator crash.