### PR TITLE
VIDEO-3721: Send message

### DIFF
--- a/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
@@ -21,6 +21,7 @@ protocol ChatStoreWriting: AnyObject {
     var messages: [TCHMessage] { get }
     func connect(accessToken: String, conversationName: String)
     func disconnect()
+    func sendMessage(_ message: String, completion: @escaping (NSError?) -> Void)
 }
 
 class ChatStore: NSObject, ChatStoreWriting {
@@ -64,6 +65,14 @@ class ChatStore: NSObject, ChatStoreWriting {
         messages = []
         conversationName = ""
         connectionState = .disconnected
+    }
+
+    func sendMessage(_ message: String, completion: @escaping (NSError?) -> Void) {
+        let options = TCHMessageOptions().withBody(message)
+        
+        conversation?.sendMessage(with: options) { result, _ in
+            completion(result.error)
+        }
     }
 
     private func getConversation() {

--- a/VideoApp/VideoApp/Storyboards/Base.lproj/Main.storyboard
+++ b/VideoApp/VideoApp/Storyboards/Base.lproj/Main.storyboard
@@ -916,6 +916,11 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="Chat" id="BNo-pd-rzu">
+                        <barButtonItem key="leftBarButtonItem" systemItem="compose" id="bb2-to-nlR">
+                            <connections>
+                                <action selector="composeTap:" destination="sC1-s8-BYs" id="DBH-kS-TH4"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" style="done" systemItem="done" id="NFQ-s1-YT7">
                             <connections>
                                 <action selector="doneTap:" destination="sC1-s8-BYs" id="dPu-hp-dt1"/>

--- a/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
@@ -25,6 +25,31 @@ class ChatViewController: UIViewController {
         print("Messages: \(chatStore.messages)")
     }
     
+    @IBAction func composeTap(_ sender: Any) {
+        let alertController = UIAlertController(title: "New Message", message: nil, preferredStyle: .alert)
+
+        alertController.addTextField { textField in
+            textField.placeholder = "Message"
+        }
+
+        let sendAction = UIAlertAction(title: "Send", style: .default) { [weak self] _ in
+            guard let text = alertController.textFields?.first?.text else { return }
+            
+            self?.chatStore.sendMessage(text) { error in
+                guard let error = error else { return }
+
+                print("Send error: \(error)")
+            }
+        }
+
+        alertController.addAction(sendAction)
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        alertController.addAction(cancelAction)
+
+        present(alertController, animated: true, completion: nil)
+    }
+    
     @IBAction func doneTap(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/VIDEO-3721

### Changes

1. Add send message to `ChatStore` and compose button to placeholder UI.
2. FYI the sent message will be added to the message list in the next ticket that handles incoming messages from the SDK. Should be speedy since the chat SDK uses sockets.

### Testing

1. Tested success by taping chat button > compose > enter message > send > done > disconnect from video room > reconnect to the same video room > tap chat > verify sent message is output in log. We have to go back out to the lobby to force chat messages to be reloaded because we aren't handling new messages yet.
2. Tested failure by taping chat button > compose > enter message > disable Wi-Fi in control center > send > wait 90 seconds for the chat SDK to report error > verify send error is output in log.