### PR TITLE
VIDEO-3724: Receive new messages

### DIFF
--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -417,8 +417,8 @@
 		DCF4590D25E5811900192F11 /* ChatTextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4590B25E5811900192F11 /* ChatTextMessage.swift */; };
 		DCF4591425E5812200192F11 /* ChatFileMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4591325E5812200192F11 /* ChatFileMessage.swift */; };
 		DCF4591525E5812200192F11 /* ChatFileMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4591325E5812200192F11 /* ChatFileMessage.swift */; };
-		DCF4592925E6C0F300192F11 /* ChatUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4592825E6C0F300192F11 /* ChatUpdate.swift */; };
-		DCF4592A25E6C0F300192F11 /* ChatUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4592825E6C0F300192F11 /* ChatUpdate.swift */; };
+		DCF4592925E6C0F300192F11 /* ChatStoreUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4592825E6C0F300192F11 /* ChatStoreUpdate.swift */; };
+		DCF4592A25E6C0F300192F11 /* ChatStoreUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4592825E6C0F300192F11 /* ChatStoreUpdate.swift */; };
 		DCF4614D238598C700DD8FEA /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */; };
 		DCF4614E238598C700DD8FEA /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */; };
 		DCF4615223859BA400DD8FEA /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4615023859BA400DD8FEA /* AppInfo.swift */; };
@@ -722,7 +722,7 @@
 		DCF4590325E5811000192F11 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		DCF4590B25E5811900192F11 /* ChatTextMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextMessage.swift; sourceTree = "<group>"; };
 		DCF4591325E5812200192F11 /* ChatFileMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileMessage.swift; sourceTree = "<group>"; };
-		DCF4592825E6C0F300192F11 /* ChatUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUpdate.swift; sourceTree = "<group>"; };
+		DCF4592825E6C0F300192F11 /* ChatStoreUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStoreUpdate.swift; sourceTree = "<group>"; };
 		DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		DCF4615023859BA400DD8FEA /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		DCF4615423859BB800DD8FEA /* AppInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoStore.swift; sourceTree = "<group>"; };
@@ -1460,8 +1460,8 @@
 				DCF4591325E5812200192F11 /* ChatFileMessage.swift */,
 				DCF4590325E5811000192F11 /* ChatMessage.swift */,
 				DCBEA3CC25CC892F00684ED2 /* ChatStore.swift */,
+				DCF4592825E6C0F300192F11 /* ChatStoreUpdate.swift */,
 				DCF4590B25E5811900192F11 /* ChatTextMessage.swift */,
-				DCF4592825E6C0F300192F11 /* ChatUpdate.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -2330,7 +2330,7 @@
 				DCC7E35E24070C5200431AC3 /* AuthFlowFactory.swift in Sources */,
 				DC85CA6223CE4FCA00BF016F /* AppCenterStoreFactory.swift in Sources */,
 				DCC7E3562406ED3900431AC3 /* UserDefaultsProtocol.swift in Sources */,
-				DCF4592925E6C0F300192F11 /* ChatUpdate.swift in Sources */,
+				DCF4592925E6C0F300192F11 /* ChatStoreUpdate.swift in Sources */,
 				DCEDB3212464CF90006AF70D /* RoomState.swift in Sources */,
 				DC44C2CA2387118400205174 /* UITableViewCellHelpers.swift in Sources */,
 				DC39248A2416A1D80068E33F /* SelectEnvironmentViewModelFactory.swift in Sources */,
@@ -2514,7 +2514,7 @@
 				DCC7E35F24070C5200431AC3 /* AuthFlowFactory.swift in Sources */,
 				DC85CA6323CE4FCA00BF016F /* AppCenterStoreFactory.swift in Sources */,
 				DCC7E3572406ED3900431AC3 /* UserDefaultsProtocol.swift in Sources */,
-				DCF4592A25E6C0F300192F11 /* ChatUpdate.swift in Sources */,
+				DCF4592A25E6C0F300192F11 /* ChatStoreUpdate.swift in Sources */,
 				DCEDB3222464CF90006AF70D /* RoomState.swift in Sources */,
 				DC44C2CB2387118400205174 /* UITableViewCellHelpers.swift in Sources */,
 				DC39248B2416A1D80068E33F /* SelectEnvironmentViewModelFactory.swift in Sources */,

--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -417,6 +417,8 @@
 		DCF4590D25E5811900192F11 /* ChatTextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4590B25E5811900192F11 /* ChatTextMessage.swift */; };
 		DCF4591425E5812200192F11 /* ChatFileMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4591325E5812200192F11 /* ChatFileMessage.swift */; };
 		DCF4591525E5812200192F11 /* ChatFileMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4591325E5812200192F11 /* ChatFileMessage.swift */; };
+		DCF4592925E6C0F300192F11 /* ChatUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4592825E6C0F300192F11 /* ChatUpdate.swift */; };
+		DCF4592A25E6C0F300192F11 /* ChatUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4592825E6C0F300192F11 /* ChatUpdate.swift */; };
 		DCF4614D238598C700DD8FEA /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */; };
 		DCF4614E238598C700DD8FEA /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */; };
 		DCF4615223859BA400DD8FEA /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4615023859BA400DD8FEA /* AppInfo.swift */; };
@@ -720,6 +722,7 @@
 		DCF4590325E5811000192F11 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		DCF4590B25E5811900192F11 /* ChatTextMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextMessage.swift; sourceTree = "<group>"; };
 		DCF4591325E5812200192F11 /* ChatFileMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileMessage.swift; sourceTree = "<group>"; };
+		DCF4592825E6C0F300192F11 /* ChatUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUpdate.swift; sourceTree = "<group>"; };
 		DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		DCF4615023859BA400DD8FEA /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		DCF4615423859BB800DD8FEA /* AppInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoStore.swift; sourceTree = "<group>"; };
@@ -1458,6 +1461,7 @@
 				DCF4590325E5811000192F11 /* ChatMessage.swift */,
 				DCBEA3CC25CC892F00684ED2 /* ChatStore.swift */,
 				DCF4590B25E5811900192F11 /* ChatTextMessage.swift */,
+				DCF4592825E6C0F300192F11 /* ChatUpdate.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -2326,6 +2330,7 @@
 				DCC7E35E24070C5200431AC3 /* AuthFlowFactory.swift in Sources */,
 				DC85CA6223CE4FCA00BF016F /* AppCenterStoreFactory.swift in Sources */,
 				DCC7E3562406ED3900431AC3 /* UserDefaultsProtocol.swift in Sources */,
+				DCF4592925E6C0F300192F11 /* ChatUpdate.swift in Sources */,
 				DCEDB3212464CF90006AF70D /* RoomState.swift in Sources */,
 				DC44C2CA2387118400205174 /* UITableViewCellHelpers.swift in Sources */,
 				DC39248A2416A1D80068E33F /* SelectEnvironmentViewModelFactory.swift in Sources */,
@@ -2509,6 +2514,7 @@
 				DCC7E35F24070C5200431AC3 /* AuthFlowFactory.swift in Sources */,
 				DC85CA6323CE4FCA00BF016F /* AppCenterStoreFactory.swift in Sources */,
 				DCC7E3572406ED3900431AC3 /* UserDefaultsProtocol.swift in Sources */,
+				DCF4592A25E6C0F300192F11 /* ChatUpdate.swift in Sources */,
 				DCEDB3222464CF90006AF70D /* RoomState.swift in Sources */,
 				DC44C2CB2387118400205174 /* UITableViewCellHelpers.swift in Sources */,
 				DC39248B2416A1D80068E33F /* SelectEnvironmentViewModelFactory.swift in Sources */,

--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -411,6 +411,12 @@
 		DCEDB3A12476C531006AF70D /* SelectHighRenderDimensionsViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEDB39E2476C531006AF70D /* SelectHighRenderDimensionsViewModelFactory.swift */; };
 		DCF458ED25E0754700192F11 /* ChatConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF458EC25E0754700192F11 /* ChatConnectionState.swift */; };
 		DCF458EE25E0754700192F11 /* ChatConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF458EC25E0754700192F11 /* ChatConnectionState.swift */; };
+		DCF4590425E5811000192F11 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4590325E5811000192F11 /* ChatMessage.swift */; };
+		DCF4590525E5811000192F11 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4590325E5811000192F11 /* ChatMessage.swift */; };
+		DCF4590C25E5811900192F11 /* ChatTextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4590B25E5811900192F11 /* ChatTextMessage.swift */; };
+		DCF4590D25E5811900192F11 /* ChatTextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4590B25E5811900192F11 /* ChatTextMessage.swift */; };
+		DCF4591425E5812200192F11 /* ChatFileMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4591325E5812200192F11 /* ChatFileMessage.swift */; };
+		DCF4591525E5812200192F11 /* ChatFileMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4591325E5812200192F11 /* ChatFileMessage.swift */; };
 		DCF4614D238598C700DD8FEA /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */; };
 		DCF4614E238598C700DD8FEA /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */; };
 		DCF4615223859BA400DD8FEA /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF4615023859BA400DD8FEA /* AppInfo.swift */; };
@@ -711,6 +717,9 @@
 		DCEDB39A2475D4D9006AF70D /* SelectStandardRenderDimensionsViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectStandardRenderDimensionsViewModelFactory.swift; sourceTree = "<group>"; };
 		DCEDB39E2476C531006AF70D /* SelectHighRenderDimensionsViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectHighRenderDimensionsViewModelFactory.swift; sourceTree = "<group>"; };
 		DCF458EC25E0754700192F11 /* ChatConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConnectionState.swift; sourceTree = "<group>"; };
+		DCF4590325E5811000192F11 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
+		DCF4590B25E5811900192F11 /* ChatTextMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextMessage.swift; sourceTree = "<group>"; };
+		DCF4591325E5812200192F11 /* ChatFileMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileMessage.swift; sourceTree = "<group>"; };
 		DCF4614B238598C700DD8FEA /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		DCF4615023859BA400DD8FEA /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		DCF4615423859BB800DD8FEA /* AppInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoStore.swift; sourceTree = "<group>"; };
@@ -1445,7 +1454,10 @@
 			isa = PBXGroup;
 			children = (
 				DCF458EC25E0754700192F11 /* ChatConnectionState.swift */,
+				DCF4591325E5812200192F11 /* ChatFileMessage.swift */,
+				DCF4590325E5811000192F11 /* ChatMessage.swift */,
 				DCBEA3CC25CC892F00684ED2 /* ChatStore.swift */,
+				DCF4590B25E5811900192F11 /* ChatTextMessage.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -2378,6 +2390,7 @@
 				DCA53949235F53E700CA26FB /* InternalAuthStore.swift in Sources */,
 				DCBEA3DA25CC966E00684ED2 /* ChatViewController.swift in Sources */,
 				DCEDB377247443E3006AF70D /* SelectDominantSpeakerPriorityViewModelFactory.swift in Sources */,
+				DCF4591425E5812200192F11 /* ChatFileMessage.swift in Sources */,
 				DCEDB356246F1702006AF70D /* LocalVideoTrack.swift in Sources */,
 				DC4568872385D5490069BB5A /* ViewControllerFactory.swift in Sources */,
 				DCAEBF40238444D500141D2D /* SelectOptionViewModel.swift in Sources */,
@@ -2394,6 +2407,7 @@
 				DC4E4E2023577EA700C5D313 /* AppSettingsStore.swift in Sources */,
 				DCEDB37B24744734006AF70D /* TrackSwitchOffMode.swift in Sources */,
 				DCEDB373247442D9006AF70D /* TrackPriority.swift in Sources */,
+				DCF4590C25E5811900192F11 /* ChatTextMessage.swift in Sources */,
 				DC44C2E723876AFB00205174 /* SelectOptionSegueSender.swift in Sources */,
 				DCB7C18F2405C0BE009DEA70 /* KeychainStorage.swift in Sources */,
 				DC44C2E323875C4F00205174 /* StringHelpers.swift in Sources */,
@@ -2458,6 +2472,7 @@
 				DCC7E36224082EB300431AC3 /* AuthError.swift in Sources */,
 				DCAEBF1D2383342C00141D2D /* DestructiveButtonCell.swift in Sources */,
 				DC9A5E3C2463161400E4B079 /* CircleView.swift in Sources */,
+				DCF4590425E5811000192F11 /* ChatMessage.swift in Sources */,
 				DC9A5E402463239E00E4B079 /* ToggleButton.swift in Sources */,
 				DCEDB34E246F16C6006AF70D /* VideoSource.swift in Sources */,
 				DCEDB32D2464F815006AF70D /* UICollectionViewHelpers.swift in Sources */,
@@ -2558,6 +2573,7 @@
 				DCA5394A235F53E700CA26FB /* InternalAuthStore.swift in Sources */,
 				DCBEA3DB25CC966E00684ED2 /* ChatViewController.swift in Sources */,
 				DCEDB378247443E3006AF70D /* SelectDominantSpeakerPriorityViewModelFactory.swift in Sources */,
+				DCF4591525E5812200192F11 /* ChatFileMessage.swift in Sources */,
 				DCEDB357246F1702006AF70D /* LocalVideoTrack.swift in Sources */,
 				DC4568882385D5490069BB5A /* ViewControllerFactory.swift in Sources */,
 				DCAEBF41238444D500141D2D /* SelectOptionViewModel.swift in Sources */,
@@ -2574,6 +2590,7 @@
 				DC4E4E2123577EA700C5D313 /* AppSettingsStore.swift in Sources */,
 				DCEDB37C24744734006AF70D /* TrackSwitchOffMode.swift in Sources */,
 				DCEDB374247442D9006AF70D /* TrackPriority.swift in Sources */,
+				DCF4590D25E5811900192F11 /* ChatTextMessage.swift in Sources */,
 				DC44C2E823876AFB00205174 /* SelectOptionSegueSender.swift in Sources */,
 				DCB7C1902405C0BE009DEA70 /* KeychainStorage.swift in Sources */,
 				DC44C2E423875C4F00205174 /* StringHelpers.swift in Sources */,
@@ -2638,6 +2655,7 @@
 				DCC7E36324082EB300431AC3 /* AuthError.swift in Sources */,
 				DCAEBF1E2383342C00141D2D /* DestructiveButtonCell.swift in Sources */,
 				DC9A5E3D2463161400E4B079 /* CircleView.swift in Sources */,
+				DCF4590525E5811000192F11 /* ChatMessage.swift in Sources */,
 				DC9A5E412463239E00E4B079 /* ToggleButton.swift in Sources */,
 				DCEDB34F246F16C6006AF70D /* VideoSource.swift in Sources */,
 				DCEDB32E2464F815006AF70D /* UICollectionViewHelpers.swift in Sources */,

--- a/VideoApp/VideoApp/Stores/Chat/ChatFileMessage.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatFileMessage.swift
@@ -23,9 +23,9 @@ class ChatFileMessage: ChatMessage {
     
     init?(message: TCHMessage) {
         guard
+            message.messageType == .media,
             let dateCreated = message.dateCreatedAsDate,
-            let author = message.author,
-            message.messageType == .media
+            let author = message.author
         else {
             return nil
         }

--- a/VideoApp/VideoApp/Stores/Chat/ChatFileMessage.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatFileMessage.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright (C) 2021 Twilio, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import TwilioConversationsClient
+
+class ChatFileMessage: ChatMessage {
+    let author: String
+    let dateCreated: Date
+    private let message: TCHMessage
+    
+    init?(message: TCHMessage) {
+        guard
+            let dateCreated = message.dateCreatedAsDate,
+            let author = message.author,
+            message.messageType == .media
+        else {
+            return nil
+        }
+
+        self.author = author
+        self.dateCreated = dateCreated
+        self.message = message
+    }
+}

--- a/VideoApp/VideoApp/Stores/Chat/ChatFileMessage.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatFileMessage.swift
@@ -19,11 +19,14 @@ import TwilioConversationsClient
 class ChatFileMessage: ChatMessage {
     let author: String
     let dateCreated: Date
+    let fileName: String
+    var fileSize: UInt { message.mediaSize }
     private let message: TCHMessage
-    
+
     init?(message: TCHMessage) {
         guard
             message.messageType == .media,
+            let fileName = message.mediaFilename,
             let dateCreated = message.dateCreatedAsDate,
             let author = message.author
         else {
@@ -33,5 +36,17 @@ class ChatFileMessage: ChatMessage {
         self.author = author
         self.dateCreated = dateCreated
         self.message = message
+        self.fileName = fileName
+    }
+    
+    func getTemporaryURL(completion: @escaping (Result<String, NSError>) -> Void) {
+        message.getMediaContentTemporaryUrl { result, url in
+            guard let url = url else {
+                completion(.failure(result.error!))
+                return
+            }
+            
+            completion(.success(url))
+        }
     }
 }

--- a/VideoApp/VideoApp/Stores/Chat/ChatMessage.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatMessage.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (C) 2021 Twilio, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+protocol ChatMessage: AnyObject {
+    var author: String { get }
+    var dateCreated: Date { get }
+}

--- a/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
@@ -83,7 +83,7 @@ class ChatStore: NSObject, ChatStoreWriting {
             completion(result.error)
         }
     }
-    
+
     private func getConversation() {
         client?.conversation(withSidOrUniqueName: conversationName) { [weak self] _, conversation in
             guard let conversation = conversation else { self?.disconnect(); return }

--- a/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
@@ -27,12 +27,6 @@ protocol ChatStoreWriting: AnyObject {
 }
 
 class ChatStore: NSObject, ChatStoreWriting {
-    enum Update { // TODO: Move
-        case didChangeConnectionState
-        case didChangeHasUnreadMessage
-        case didReceiveNewMessage(message: ChatMessage) // TODO: Need parameter?
-    }
-
     static let shared: ChatStoreWriting = ChatStore()
     var isReading = false {
         didSet {
@@ -52,7 +46,7 @@ class ChatStore: NSObject, ChatStoreWriting {
     
     func connect(accessToken: String, conversationName: String) {
         if connectionState != .disconnected {
-            disconnect() // TODO: Improve?
+            disconnect()
         }
 
         connectionState = .connecting
@@ -115,7 +109,7 @@ class ChatStore: NSObject, ChatStoreWriting {
         }
     }
     
-    private func post(_ update: Update) {
+    private func post(_ update: ChatUpdate) {
         notificationCenter.post(name: .chatStoreUpdate, object: self, payload: update)
     }
 }
@@ -152,6 +146,6 @@ extension ChatStore: TwilioConversationsClientDelegate {
             post(.didChangeHasUnreadMessage)
         }
 
-        post(.didReceiveNewMessage(message: message))
+        post(.didReceiveNewMessage)
     }
 }

--- a/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
@@ -18,7 +18,7 @@ import TwilioConversationsClient
 
 protocol ChatStoreWriting: AnyObject {
     var connectionState: ChatConnectionState { get }
-    var messages: [TCHMessage] { get }
+    var messages: [ChatMessageGroup] { get }
     func connect(accessToken: String, conversationName: String)
     func disconnect()
     func sendMessage(_ message: String, completion: @escaping (NSError?) -> Void)
@@ -33,7 +33,7 @@ class ChatStore: NSObject, ChatStoreWriting {
     private(set) var connectionState: ChatConnectionState = .disconnected {
         didSet { post(.didChangeConnectionState) }
     }
-    private(set) var messages: [TCHMessage] = []
+    private(set) var messages: [ChatMessageGroup] = []
     private let notificationCenter = NotificationCenter.default
     private var client: TwilioConversationsClient?
     private var conversation: TCHConversation?
@@ -109,5 +109,15 @@ extension ChatStore: TwilioConversationsClientDelegate {
         case .failed: disconnect()
         @unknown default: return
         }
+    }
+    
+    func conversationsClient(
+        _ client: TwilioConversationsClient,
+        conversation: TCHConversation,
+        messageAdded message: TCHMessage
+    ) {
+        guard conversation.sid == self.conversation?.sid else { return }
+        
+        
     }
 }

--- a/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatStore.swift
@@ -19,7 +19,7 @@ import TwilioConversationsClient
 protocol ChatStoreWriting: AnyObject {
     var connectionState: ChatConnectionState { get }
     var messages: [ChatMessage] { get }
-    var isReading: Bool { get set }
+    var isUserReadingMessages: Bool { get set }
     var hasUnreadMessage: Bool { get }
     func connect(accessToken: String, conversationName: String)
     func disconnect()
@@ -28,9 +28,9 @@ protocol ChatStoreWriting: AnyObject {
 
 class ChatStore: NSObject, ChatStoreWriting {
     static let shared: ChatStoreWriting = ChatStore()
-    var isReading = false {
+    var isUserReadingMessages = false {
         didSet {
-            guard isReading && hasUnreadMessage else { return }
+            guard isUserReadingMessages && hasUnreadMessage else { return }
 
             hasUnreadMessage = false
             post(.didChangeHasUnreadMessage)
@@ -113,7 +113,7 @@ class ChatStore: NSObject, ChatStoreWriting {
         ChatTextMessage(message: message) ?? ChatFileMessage(message: message)
     }
     
-    private func post(_ update: ChatUpdate) {
+    private func post(_ update: ChatStoreUpdate) {
         notificationCenter.post(name: .chatStoreUpdate, object: self, payload: update)
     }
 }
@@ -140,7 +140,7 @@ extension ChatStore: TwilioConversationsClientDelegate {
 
         messages.append(message)
         
-        if !isReading {
+        if !isUserReadingMessages {
             hasUnreadMessage = true
             post(.didChangeHasUnreadMessage)
         }

--- a/VideoApp/VideoApp/Stores/Chat/ChatStoreUpdate.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatStoreUpdate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-enum ChatUpdate {
+enum ChatStoreUpdate {
     case didChangeConnectionState
     case didChangeHasUnreadMessage
     case didReceiveNewMessage

--- a/VideoApp/VideoApp/Stores/Chat/ChatTextMessage.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatTextMessage.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright (C) 2021 Twilio, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import TwilioConversationsClient
+
+class ChatTextMessage: ChatMessage {
+    let author: String
+    let dateCreated: Date
+    let body: String
+    
+    init?(message: TCHMessage) {
+        guard
+            let dateCreated = message.dateCreatedAsDate,
+            let author = message.author,
+            let body = message.body,
+            message.messageType == .text
+        else {
+            return nil
+        }
+        
+        self.author = author
+        self.dateCreated = dateCreated
+        self.body = body
+    }
+}

--- a/VideoApp/VideoApp/Stores/Chat/ChatTextMessage.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatTextMessage.swift
@@ -23,10 +23,11 @@ class ChatTextMessage: ChatMessage {
     
     init?(message: TCHMessage) {
         guard
+            message.messageType == .text,
             let dateCreated = message.dateCreatedAsDate,
             let author = message.author,
-            let body = message.body,
-            message.messageType == .text
+            let body = message.body
+            
         else {
             return nil
         }

--- a/VideoApp/VideoApp/Stores/Chat/ChatUpdate.swift
+++ b/VideoApp/VideoApp/Stores/Chat/ChatUpdate.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (C) 2021 Twilio, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+enum ChatUpdate {
+    case didChangeConnectionState
+    case didChangeHasUnreadMessage
+    case didReceiveNewMessage
+}

--- a/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
@@ -65,15 +65,15 @@ class ChatViewController: UIViewController {
     }
 
     @objc private func handleChatStoreUpdate(_ notification: Notification) {
-        guard let payload = notification.payload as? ChatStore.Update else { return }
+        guard let payload = notification.payload as? ChatUpdate else { return }
 
         switch payload {
         case .didChangeConnectionState, .didChangeHasUnreadMessage:
             break
-        case let .didReceiveNewMessage(message):
-            if let textMessage = message as? ChatTextMessage {
+        case .didReceiveNewMessage:
+            if let textMessage = chatStore.messages.last as? ChatTextMessage {
                 print("Text message: \(textMessage.body)")
-            } else if let fileMessage = message as? ChatFileMessage {
+            } else if let fileMessage = chatStore.messages.last as? ChatFileMessage {
                 print("File message: \(fileMessage)")
             }
         }

--- a/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
@@ -29,15 +29,16 @@ class ChatViewController: UIViewController {
             object: chatStore
         )
         
-        chatStore.isReading = true
+        chatStore.isUserReadingMessages = true
         
-        print("Messages: \(chatStore.messages)")
+        print("Chat > All messages:")
+        chatStore.messages.forEach { print("    \($0)") }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        chatStore.isReading = false
+        chatStore.isUserReadingMessages = false
     }
     
     @IBAction func composeTap(_ sender: Any) {
@@ -53,7 +54,7 @@ class ChatViewController: UIViewController {
             self?.chatStore.sendMessage(text) { error in
                 guard let error = error else { return }
 
-                print("Send error: \(error)")
+                print("Chat > Send message error:\n    \(error)")
             }
         }
 
@@ -70,17 +71,25 @@ class ChatViewController: UIViewController {
     }
 
     @objc private func handleChatStoreUpdate(_ notification: Notification) {
-        guard let payload = notification.payload as? ChatUpdate else { return }
+        guard let payload = notification.payload as? ChatStoreUpdate else { return }
 
         switch payload {
         case .didChangeConnectionState, .didChangeHasUnreadMessage:
             break
         case .didReceiveNewMessage:
             if let textMessage = chatStore.messages.last as? ChatTextMessage {
-                print("Text message: \(textMessage.body)")
+                print("Chat > Received text message:\n    \(textMessage)")
             } else if let fileMessage = chatStore.messages.last as? ChatFileMessage {
-                print("File message: \(fileMessage)")
+                print("Chat > Received file message:\n    \(fileMessage)")
             }
         }
     }
+}
+
+extension ChatTextMessage: CustomStringConvertible {
+    var description: String { "\(dateCreated) | \(author) | \(body)" }
+}
+
+extension ChatFileMessage: CustomStringConvertible {
+    var description: String { "\(dateCreated) | \(author) | \(fileName) | \(fileSize)" }
 }

--- a/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
@@ -22,7 +22,17 @@ class ChatViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NotificationCenter.default.addObserver(self, selector: #selector(handleChatStoreUpdate), name: .chatStoreUpdate, object: chatStore)
+        
+        chatStore.isReading = true
+        
         print("Messages: \(chatStore.messages)")
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        chatStore.isReading = false
     }
     
     @IBAction func composeTap(_ sender: Any) {
@@ -52,5 +62,20 @@ class ChatViewController: UIViewController {
     
     @IBAction func doneTap(_ sender: Any) {
         dismiss(animated: true, completion: nil)
+    }
+
+    @objc private func handleChatStoreUpdate(_ notification: Notification) {
+        guard let payload = notification.payload as? ChatStore.Update else { return }
+
+        switch payload {
+        case .didChangeConnectionState, .didChangeHasUnreadMessage:
+            break
+        case let .didReceiveNewMessage(message):
+            if let textMessage = message as? ChatTextMessage {
+                print("Text message: \(textMessage.body)")
+            } else if let fileMessage = message as? ChatFileMessage {
+                print("File message: \(fileMessage)")
+            }
+        }
     }
 }

--- a/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Chat/ChatViewController.swift
@@ -22,7 +22,12 @@ class ChatViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NotificationCenter.default.addObserver(self, selector: #selector(handleChatStoreUpdate), name: .chatStoreUpdate, object: chatStore)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleChatStoreUpdate),
+            name: .chatStoreUpdate,
+            object: chatStore
+        )
         
         chatStore.isReading = true
         

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewController.swift
@@ -135,6 +135,7 @@ extension RoomViewController: RoomViewModelDelegate {
     
     func didUpdateChat() {
         chatButton.isEnabled = viewModel.data.isChatConnected
+        print("Unread messages: \(viewModel.data.hasUnreadChatMessage)")
     }
 }
 

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewController.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewController.swift
@@ -135,7 +135,7 @@ extension RoomViewController: RoomViewModelDelegate {
     
     func didUpdateChat() {
         chatButton.isEnabled = viewModel.data.isChatConnected
-        print("Unread messages: \(viewModel.data.hasUnreadChatMessage)")
+        print("Room > Has unread messages:\n    \(viewModel.data.hasUnreadChatMessage)")
     }
 }
 

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
@@ -39,7 +39,8 @@ class RoomViewModel {
                 videoTrack: mainParticipantStore.videoTrack
             ),
             isRecording: room.isRecording,
-            isChatConnected: chatStore.connectionState == .connected
+            isChatConnected: chatStore.connectionState == .connected,
+            hasUnreadChatMessage: chatStore.hasUnreadMessage
         )
     }
     var isMicOn: Bool {
@@ -132,7 +133,7 @@ class RoomViewModel {
         guard let payload = notification.payload as? ChatStore.Update else { return }
 
         switch payload {
-        case .didChangeConnectionState: delegate?.didUpdateChat()
+        case .didChangeConnectionState, .didReceiveNewMessage, .didChangeHasUnreadMessage: delegate?.didUpdateChat()
         }
     }
 }

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
@@ -133,7 +133,8 @@ class RoomViewModel {
         guard let payload = notification.payload as? ChatUpdate else { return }
 
         switch payload {
-        case .didChangeConnectionState, .didReceiveNewMessage, .didChangeHasUnreadMessage: delegate?.didUpdateChat()
+        case .didChangeConnectionState, .didChangeHasUnreadMessage: delegate?.didUpdateChat()
+        case .didReceiveNewMessage: break
         }
     }
 }

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
@@ -130,7 +130,7 @@ class RoomViewModel {
     }
 
     @objc private func handleChatStoreUpdate(_ notification: Notification) {
-        guard let payload = notification.payload as? ChatStore.Update else { return }
+        guard let payload = notification.payload as? ChatUpdate else { return }
 
         switch payload {
         case .didChangeConnectionState, .didReceiveNewMessage, .didChangeHasUnreadMessage: delegate?.didUpdateChat()

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewModel.swift
@@ -130,7 +130,7 @@ class RoomViewModel {
     }
 
     @objc private func handleChatStoreUpdate(_ notification: Notification) {
-        guard let payload = notification.payload as? ChatUpdate else { return }
+        guard let payload = notification.payload as? ChatStoreUpdate else { return }
 
         switch payload {
         case .didChangeConnectionState, .didChangeHasUnreadMessage: delegate?.didUpdateChat()

--- a/VideoApp/VideoApp/ViewControllers/Room/RoomViewModelData.swift
+++ b/VideoApp/VideoApp/ViewControllers/Room/RoomViewModelData.swift
@@ -32,4 +32,5 @@ struct RoomViewModelData {
     let mainParticipant: MainParticipant
     let isRecording: Bool
     let isChatConnected: Bool
+    let hasUnreadChatMessage: Bool
 }


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/VIDEO-3724

### Changes

1. Make `ChatStore` receive new messages.
2. Make `ChatStore` keep track if there are any unread messages.
3. Make `ChatStore` immediately mark new messages as read if the user is currently inside chat UI.
4. `ChatStore` can now handle all basic chat features. The only thing I am aware might require more changes to `ChatStore` is grouping of messages by author and date. This could be done in either the view model or `ChatStore`. Grouping will be one of the last tickets I work on.

### Testing

1. Used log output to verify unread status is correct after chat is connected.
2. Used log output to verify unread status changes correctly on the room screen when user is not inside chat screen.
2. Used log output to verify unread status is always false on the room screen when user is inside chat screen.
3. Used log to verify message sent from same device is received as new message.
4. Used log to verify message sent from different device is received as new message.
5. I implemented the file message but I don't have a good way to test it yet. However I thought it made sense to take a crack at it to make sure general architecture was ok.