### PR TITLE
Fix error view visiblity when video track is nil

### DIFF
--- a/VideoApp/VideoApp/Views/VideoView/VideoView.swift
+++ b/VideoApp/VideoApp/Views/VideoView/VideoView.swift
@@ -55,7 +55,7 @@ class VideoView: NibView {
     func configure(config: Config, contentMode: UIView.ContentMode = .scaleAspectFit) {
         videoView.shouldMirror = config.shouldMirror
         videoView.contentMode = contentMode
-        errorView.isHidden = !(config.videoTrack?.isSwitchedOff ?? false)
+        errorView.isHidden = !(config.videoTrack?.isSwitchedOff ?? true)
 
         if let videoTrack = config.videoTrack, videoTrack.isEnabled {
             if !videoTrack.isRendered(by: videoView) {


### PR DESCRIPTION
I believe In order to show error view when video track is nil we need to set default value to true.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
