### PR TITLE
VIDEO-6809: Add a changelog entry for the 4.5.0 support release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### New Feature
 
-- Added support for Client Track Switch Off and Video Content Preferences
+- Added support for Client Track Switch Off and Video Content Preferences.
 - Improved `UICollectionView` cell management so that tracks are switched off immediately when cells are offscreen.
 - We recommend that you review the [ParticipantCell](https://github.com/twilio/twilio-video-app-ios/blob/v0.81/VideoApp/VideoApp/Views/Cells/Participant/ParticipantCell.swift) and [VideoView](https://github.com/twilio/twilio-video-app-ios/blob/v0.81/VideoApp/VideoApp/Views/VideoView/VideoView.swift) implementations if you use `UICollectionView` and want to update your application for Client Track Switch Off.
 - For more information, please view this [blog post](https://www.twilio.com/blog/improve-efficiency-multi-party-video-experiences) and feature [documentation](https://www.twilio.com/docs/video/tutorials/using-bandwidth-profile-api#understanding-clientTrackSwitchOffControl).
 
 ### Bugs
 
-- Fixed a visual issue where the `UICollectionView` had leading space to its superview
+- Fixed a visual issue where the `UICollectionView` had leading space to its superview.
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Change Log
 
-### 0.1.0
+## 0.81 (August 27, 2021)
+
+### New Feature
+
+- Added support for Client Track Switch Off and Video Content Preferences
+- Improved `UICollectionView` cell management so that tracks are switched off immediately when cells are offscreen.
+- We recommend that you review the [ParticipantCell](https://github.com/twilio/twilio-video-app-ios/blob/v0.81/VideoApp/VideoApp/Views/Cells/Participant/ParticipantCell.swift) and [VideoView](https://github.com/twilio/twilio-video-app-ios/blob/v0.81/VideoApp/VideoApp/Views/VideoView/VideoView.swift) implementations if you use `UICollectionView` and want to update your application for Client Track Switch Off.
+- For more information, please view this [blog post](https://www.twilio.com/blog/improve-efficiency-multi-party-video-experiences) and feature [documentation](https://www.twilio.com/docs/video/tutorials/using-bandwidth-profile-api#understanding-clientTrackSwitchOffControl).
+
+### Bugs
+
+- Fixed a visual issue where the `UICollectionView` had leading space to its superview
+
+### Maintenance
+
+- Removed support for the deprectated `maxTracks` and `renderDimensions` properties in `VideoBandwidthProfileOptions`.
+
+### Dependency Upgrades
+
+- `twilio-video-ios` has been updated from 4.4.0 to 4.5.0, and 4.5.0 is now the minimum required version. [#169](https://github.com/twilio/twilio-video-app-ios/pull/169)
+
+-----------
+
+## 0.1.0
 
 This release marks the first iteration of the Twilio Video Collaboration App: a multi-party collaboration video application built with Programmable Video. This application is intended to demonstrate the capabilities of Programmable Video and serve as a reference to developers building video apps. 
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ UI tests require credentials that are only available to Twilio employees.
 
 ## Related
 
-- [Change Log](CHANGELOG.md)
 - [Twilio Video Android App](https://github.com/twilio/twilio-video-app-android)
 - [Twilio Video React App](https://github.com/twilio/twilio-video-app-react)
 - [Twilio CLI RTC Plugin](https://github.com/twilio-labs/plugin-rtc)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ UI tests require credentials that are only available to Twilio employees.
 
 ## Related
 
+- [Change Log](CHANGELOG.md)
 - [Twilio Video Android App](https://github.com/twilio/twilio-video-app-android)
 - [Twilio Video React App](https://github.com/twilio/twilio-video-app-react)
 - [Twilio CLI RTC Plugin](https://github.com/twilio-labs/plugin-rtc)


### PR DESCRIPTION
After meeting with @spalmertwilio and @mmartikainen we agreed that it would be good to document important releases of Video App in the changelog.

In this PR I have added an entry for v0.81 which was the tagged version where we added support for Video Content Preferences and Client Track Switch Off Control. Customers who referenced the code might want to return for pointers on how to update their own apps to best take advantage of the 4.5.0 SDK release.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
