### PR TITLE
VIDEO-6636: Update TwilioVideo dependency to 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.82 (September 17, 2021)
+
+### Dependency Upgrades
+
+- `twilio-video-ios` has been updated from 4.5.0 to 4.6.0. [#169](https://github.com/twilio/twilio-video-app-ios/pull/170)
+
 ## 0.81 (August 27, 2021)
 
 ### New Feature

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -106,7 +106,7 @@ PODS:
   - Nimble (9.2.0)
   - PromisesObjC (1.2.12)
   - Quick (3.1.2)
-  - TwilioVideo (4.5.0)
+  - TwilioVideo (4.6.0)
 
 DEPENDENCIES:
   - Alamofire (~> 5)
@@ -172,7 +172,7 @@ SPEC CHECKSUMS:
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
-  TwilioVideo: a765f519bb8646187eaa0e9f7443d08529ccba0a
+  TwilioVideo: 50fe59254718d86ffb342aff397bc89ab588e577
 
 PODFILE CHECKSUM: c163b224068a95f3dc2d7bb74947cb70cb32e56a
 


### PR DESCRIPTION
This release adds support for Apple Silicon arm64 Macs, updates WebRTC and modernizes our use of several WebRTC APIs. Thank you for your feedback on 4.6.0-beta1 and for your interest in Apple Silicon development.

Features

- `TwilioVideo.xcframework` now supports the simulator on Apple Silicon arm64 Macs. [#144](https://github.com/twilio/twilio-video-ios/issues/144)
  - This results in a size increase for the SDK during development. 
  - App store download size is not affected.

Enhancements

- This release is based on WebRTC M88.
- The SDK uses Unified Plan SDP semantics instead of Plan-B. This brings several important benefits:
  - Improved interoperability with Firefox, Safari and Chrome in Peer-to-Peer and Go Rooms
  - Track level operations like publishing and unpublishing are more reliable
- Improved performance of `Room.getStats()` by adopting the W3C standardized RTC stats API
- Unused codecs for a track are removed from the local SDP offer in order to reduce the SDP size, once codecs for the track have been negotiated. [VIDEO-3532]

API Changes

- The ordering of `RemoteParticipantDelegate.onAudioTrackSubscribed()` and `RemoteParticipantDelegate.onVideoTrackSubscribed()` is not strictly guaranteed. In this release the ordering of these callbacks may be different when compared to previous releases.
- The value of `LocalVideoTrackStats.framesEncoded` now reflects the total number of frames encoded for a simulcast track.

Bug Fixes

- Fixed performance problems with `Room.getStats()` where block callbacks could sometimes be significantly delayed. [CSDK-3475]
- Fixed an interoperability issue with `twilio-video.js` when publishing media in Peer-to-Peer or WebRTC Go Rooms. [#931](https://github.com/twilio/twilio-video.js/issues/931)

Known Issues

- Audio playback fails when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Carthage is not currently a supported distribution mechanism for Twilio Video. Carthage does not currently work with `.xcframeworks` as documented [here](https://github.com/Carthage/Carthage/issues/2890). Once Carthage supports binary `.xcframeworks`, Carthage distribution will be re-added.
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
