### PR TITLE
VIDEO-XXXX upgrade to 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.85 (October 15, 2021)
+
+### Dependency Upgrades
+
+- `TwilioVideo` has been updated from 4.6.1 to 4.6.2. [#176](https://github.com/twilio/twilio-video-app-ios/pull/176)
+
+-----------
+
 ## 0.84 (October 15, 2021)
 
 ### Dependency Upgrades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependency Upgrades
 
-- `TwilioVideo` has been updated from 4.6.1 to 4.6.2. [#176](https://github.com/twilio/twilio-video-app-ios/pull/176)
+- `TwilioVideo` has been updated from 4.6.1 to 4.6.2. [#176](https://github.com/twilio/twilio-video-app-ios/pull/177)
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
-## 0.85 (October 15, 2021)
+## 0.85 (November 5, 2021)
 
 ### Dependency Upgrades
 
-- `TwilioVideo` has been updated from 4.6.1 to 4.6.2. [#176](https://github.com/twilio/twilio-video-app-ios/pull/177)
+- `TwilioVideo` has been updated from 4.6.1 to 4.6.2. [#177](https://github.com/twilio/twilio-video-app-ios/pull/177)
 
 -----------
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,7 +128,7 @@ PODS:
   - Nimble (9.2.0)
   - PromisesObjC (2.0.0)
   - Quick (3.1.2)
-  - TwilioVideo (4.6.1)
+  - TwilioVideo (4.6.2)
 
 DEPENDENCIES:
   - Alamofire (~> 5)
@@ -198,7 +198,7 @@ SPEC CHECKSUMS:
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
-  TwilioVideo: b3d34744e3860c09816e349679eb2572e8fba06c
+  TwilioVideo: f8c75425bce3f41912bb24352154b0502d89a9b3
 
 PODFILE CHECKSUM: 5ce4997325e2a0fedc4b9f550d377da8ac2e43c4
 


### PR DESCRIPTION
#### 4.6.2 (November 5, 2021)

Enhancements

- Added support for `Audio Only` rooms.
- Improved reconnection time after network connectivity disruptions.
- This release is built with Xcode 12.5.1

API Changes

- Two new error codes `TVIErrorRoomAudioOnlyFlagNotSupportedError` (53124) and `TVIErrorRoomTrackKindNotSupportedError` (53125) are added to support `Audio Only` rooms. 

Known Issues

- Audio playback fails when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Carthage is not currently a supported distribution mechanism for Twilio Video. Carthage does not currently work with `.xcframeworks` as documented [here](https://github.com/Carthage/Carthage/issues/2890). Once Carthage supports binary `.xcframeworks`, Carthage distribution will be re-added.
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

Size Impact

Architecture | Compressed Size | Uncompressed Size
------------ | --------------- | -----------------
Universal | 10.0 MB | 21.4 MB
arm64 | 4.8 MB | 11.3 MB
armv7 | 5.2 MB | 10.1 MB


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
