### PR TITLE
Add manual video layout switching

### DIFF
--- a/VideoApp/VideoApp/Assets.xcassets/Colors/BackgroundBodyInverse.colorset/Contents.json
+++ b/VideoApp/VideoApp/Assets.xcassets/Colors/BackgroundBodyInverse.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.227",
-          "green" : "0.012",
-          "red" : "0.024"
+          "blue" : "0.176",
+          "green" : "0.110",
+          "red" : "0.071"
         }
       },
       "idiom" : "universal"

--- a/VideoApp/VideoApp/Assets.xcassets/Colors/BackgroundInverseStrong.colorset/Contents.json
+++ b/VideoApp/VideoApp/Assets.xcassets/Colors/BackgroundInverseStrong.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.537",
-          "green" : "0.078",
-          "red" : "0.000"
+          "blue" : "0.384",
+          "green" : "0.278",
+          "red" : "0.223"
         }
       },
       "idiom" : "universal"

--- a/VideoApp/VideoApp/NewCode/Screens/Home/HomeView.swift
+++ b/VideoApp/VideoApp/NewCode/Screens/Home/HomeView.swift
@@ -29,6 +29,11 @@ struct HomeView: View {
     var body: some View {
         NavigationView {
             FormStack {
+                Text("Twilio Programmable Video")
+                    .font(.title.bold())
+                    .multilineTextAlignment(.center)
+                    .padding(.top, -40) /// A little clunky but `FormStack` needs some work
+                
                 Text("Enter the name of a room you'd like to join.")
                 
                 TextField("Room name", text: $roomName)
@@ -43,7 +48,6 @@ struct HomeView: View {
                 .buttonStyle(PrimaryButtonStyle(isEnabled: !roomName.isEmpty))
                 .disabled(roomName.isEmpty)
             }
-            .navigationBarTitle("Join a room", displayMode: .inline)
             .toolbar {
                 Button(action: { isShowingSettings.toggle() }) {
                     Image(systemName: "gear")

--- a/VideoApp/VideoApp/NewCode/Screens/MediaSetup/MediaSetupView.swift
+++ b/VideoApp/VideoApp/NewCode/Screens/MediaSetup/MediaSetupView.swift
@@ -49,7 +49,7 @@ struct MediaSetupView: View {
                     Spacer()
                     Spacer()
                     
-                    Button("Join now") {
+                    Button("Join Now") {
                         isMediaSetup = true
                         presentationMode.wrappedValue.dismiss()
                     }

--- a/VideoApp/VideoApp/NewCode/Screens/Room/RoomView.swift
+++ b/VideoApp/VideoApp/NewCode/Screens/Room/RoomView.swift
@@ -37,7 +37,7 @@ struct RoomView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                Color.backgroundBrandStronger.ignoresSafeArea()
+                Color.backgroundBodyInverse.ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     VStack(spacing: 0) {

--- a/VideoApp/VideoApp/NewCode/Screens/Room/RoomView.swift
+++ b/VideoApp/VideoApp/NewCode/Screens/Room/RoomView.swift
@@ -19,14 +19,10 @@ import SwiftUI
 /// Room screen that is shown when a user connects to a video room.
 struct RoomView: View {
     @EnvironmentObject var viewModel: RoomViewModel
-    @EnvironmentObject var gridLayoutViewModel: GridLayoutViewModel
-    @EnvironmentObject var focusLayoutViewModel: FocusLayoutViewModel
-    @EnvironmentObject var localParticipant: LocalParticipantManager
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.verticalSizeClass) var verticalSizeClass
     let roomName: String
-    @State var isShowingStats = false
     private let app = UIApplication.shared
     private let spacing: CGFloat = 6
     
@@ -44,10 +40,11 @@ struct RoomView: View {
                         RoomStatusView(roomName: roomName)
                             .padding(.horizontal, spacing)
 
-                        if focusLayoutViewModel.isPresenting {
-                            FocusLayoutView(spacing: spacing)
-                        } else {
+                        switch viewModel.layout {
+                        case .grid:
                             GridLayoutView(spacing: spacing)
+                        case .focus:
+                            FocusLayoutView(spacing: spacing)
                         }
                     }
                     .padding(.leading, geometry.safeAreaInsets.leading)
@@ -67,9 +64,22 @@ struct RoomView: View {
                         
                         Menu {
                             Button(
-                                action: { isShowingStats = true },
+                                action: { viewModel.isShowingStats = true },
                                 label: { Label("Stats", systemImage: "binoculars") }
                             )
+
+                            switch viewModel.layout {
+                            case .grid:
+                                Button(
+                                    action: { viewModel.switchToLayout(.focus) },
+                                    label: { Label("Switch to Focus Layout", systemImage: "person") }
+                                )
+                            case .focus:
+                                Button(
+                                    action: { viewModel.switchToLayout(.grid) },
+                                    label: { Label("Switch to Grid Layout", systemImage: "square.grid.2x2") }
+                                )
+                            }
                         } label: {
                             RoomToolbarButton(image: Image(systemName: "ellipsis"))
                         }
@@ -81,7 +91,7 @@ struct RoomView: View {
                 }
                 .edgesIgnoringSafeArea([.horizontal, .bottom]) // So toolbar sides and bottom extend beyond safe area
 
-                StatsContainerView(isShowingStats: $isShowingStats)
+                StatsContainerView(isShowingStats: $viewModel.isShowingStats)
                 
                 if viewModel.state == .connecting {
                     ProgressHUD(title: "Connecting...")
@@ -111,17 +121,19 @@ struct RoomView_Previews: PreviewProvider {
             Group {
                 RoomView(roomName: roomName)
                     .previewDisplayName("Grid layout")
+                    .environmentObject(RoomViewModel.stub())
                     .environmentObject(FocusLayoutViewModel.stub())
 
                 RoomView(roomName: roomName)
                     .previewDisplayName("Focus layout")
+                    .environmentObject(RoomViewModel.stub(layout: .focus))
                     .environmentObject(FocusLayoutViewModel.stub(isPresenting: true))
 
-                RoomView(roomName: roomName, isShowingStats: true)
+                RoomView(roomName: roomName)
                     .previewDisplayName("Stats")
+                    .environmentObject(RoomViewModel.stub(isShowingStats: true))
                     .environmentObject(FocusLayoutViewModel.stub())
             }
-            .environmentObject(RoomViewModel.stub())
             .environmentObject(GridLayoutViewModel.stub())
             .environmentObject(RoomManager.stub(isRecording: true))
 
@@ -137,9 +149,15 @@ struct RoomView_Previews: PreviewProvider {
 }
 
 extension RoomViewModel {
-    static func stub(state: State = .connected) -> RoomViewModel {
+    static func stub(
+        state: State = .connected,
+        layout: Layout = .grid,
+        isShowingStats: Bool = false
+    ) -> RoomViewModel {
         let viewModel = RoomViewModel()
         viewModel.state = state
+        viewModel.layout = layout
+        viewModel.isShowingStats = isShowingStats
         return viewModel
     }
 }

--- a/VideoApp/VideoApp/NewCode/Screens/Room/RoomViewDependencyWrapper.swift
+++ b/VideoApp/VideoApp/NewCode/Screens/Room/RoomViewDependencyWrapper.swift
@@ -41,7 +41,7 @@ struct RoomViewDependencyWrapper: View {
         .environmentObject(roomManager)
         .onAppear {
             roomManager.configure(localParticipant: localParticipant)
-            roomViewModel.configure(roomManager: roomManager)
+            roomViewModel.configure(roomManager: roomManager, focusLayoutViewModel: focusLayoutViewModel)
             gridLayoutViewModel.configure(roomManager: roomManager)
             focusLayoutViewModel.configure(roomManager: roomManager)
         }

--- a/VideoApp/VideoApp/NewCode/Screens/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/NewCode/Screens/Room/RoomViewModel.swift
@@ -22,42 +22,45 @@ import Combine
         case connecting
         case connected
     }
+    
+    enum Layout {
+        case grid
+        case focus
+    }
 
     @Published var state = State.disconnected
+    @Published var layout: Layout = .grid
+    @Published var isShowingStats = false
     @Published var isShowingError = false
     private(set) var error: Error?
     private let accessTokenStore = TwilioAccessTokenStore()
+    private var isAutoLayoutSwitchingEnabled = true
     private var roomManager: RoomManager!
+    private var focusLayoutViewModel: FocusLayoutViewModel!
     private var subscriptions = Set<AnyCancellable>()
 
-    func configure(roomManager: RoomManager) {
+    func configure(roomManager: RoomManager, focusLayoutViewModel: FocusLayoutViewModel) {
         self.roomManager = roomManager
+        self.focusLayoutViewModel = focusLayoutViewModel
 
         roomManager.roomConnectPublisher
             .sink { [weak self] in self?.state = .connected }
             .store(in: &subscriptions)
 
         roomManager.roomDisconnectPublisher
-            .sink { [weak self] error in
-                guard let error = error else {
-                    return
-                }
-                
-                self?.handleError(error)
-            }
+            .compactMap { $0 }
+            .sink { [ weak self] error in self?.handleError(error) }
             .store(in: &subscriptions)
         
         roomManager.localParticipant.errorPublisher
             .sink { [weak self] error in self?.handleError(error) }
             .store(in: &subscriptions)
+        
+        focusLayoutViewModel.$isPresenting
+            .sink { [weak self] isPresenting in self?.handleIsPresentingChange(isPresenting: isPresenting) }
+            .store(in: &subscriptions)
     }
-
-    private func handleError(_ error: Error) {
-        disconnect()
-        self.error = error
-        isShowingError = true
-    }
-
+    
     func connect(roomName: String) {
         guard roomManager != nil else {
             return /// When not configured do nothing so `PreviewProvider` doesn't crash.
@@ -80,5 +83,43 @@ import Combine
         state = .disconnected
         roomManager.localParticipant.isMicOn = false
         roomManager.localParticipant.isCameraOn = false
+    }
+
+    /// A user can manually switch layout to override auto layout.
+    func switchToLayout(_ layout: Layout) {
+        self.layout = layout
+
+        switch layout {
+        case .grid:
+            break
+        case .focus:
+            /// Turn auto layout back on when there is a presentation and the user switched back to focus layout
+            isAutoLayoutSwitchingEnabled = focusLayoutViewModel.isPresenting
+        }
+    }
+    
+    private func handleIsPresentingChange(isPresenting: Bool) {
+        if isPresenting {
+            switch layout {
+            case .grid:
+                /// The grid does not show the presentation at all so we have to auto switch to
+                /// focus to inform the user that a presentation has started
+                isAutoLayoutSwitchingEnabled = true
+            case .focus:
+                break
+            }
+
+            layout = .focus
+        } else {
+            if isAutoLayoutSwitchingEnabled {
+                layout = .grid
+            }
+        }
+    }
+
+    private func handleError(_ error: Error) {
+        disconnect()
+        self.error = error
+        isShowingError = true
     }
 }

--- a/VideoApp/VideoApp/NewCode/Views/Core/Color.swift
+++ b/VideoApp/VideoApp/NewCode/Views/Core/Color.swift
@@ -20,9 +20,9 @@ import SwiftUI
 extension Color {
     static var background: Color { Color("Background") }
     static var backgroundBodyInverse: Color { Color("BackgroundBodyInverse") }
-    static var backgroundBrand: Color { Color("BackgroundBrand") }
     static var backgroundDestructive: Color { Color("BackgroundDestructive") }
     static var backgroundHighlight: Color { Color("BackgroundHighlight") }
+    static var backgroundInverseStrong: Color { Color("BackgroundInverseStrong") }
     static var backgroundLiveBadge: Color { Color("BackgroundLiveBadge") }
     static var backgroundPrimary: Color { Color("BackgroundPrimary") }
     static var backgroundPrimaryWeak: Color { Color("BackgroundPrimaryWeak") }

--- a/VideoApp/VideoApp/NewCode/Views/Core/Color.swift
+++ b/VideoApp/VideoApp/NewCode/Views/Core/Color.swift
@@ -19,8 +19,8 @@ import SwiftUI
 // Colors defined at https://paste.twilio.design/tokens/
 extension Color {
     static var background: Color { Color("Background") }
+    static var backgroundBodyInverse: Color { Color("BackgroundBodyInverse") }
     static var backgroundBrand: Color { Color("BackgroundBrand") }
-    static var backgroundBrandStronger: Color { Color("BackgroundBrandStronger") }
     static var backgroundDestructive: Color { Color("BackgroundDestructive") }
     static var backgroundHighlight: Color { Color("BackgroundHighlight") }
     static var backgroundLiveBadge: Color { Color("BackgroundLiveBadge") }

--- a/VideoApp/VideoApp/NewCode/Views/Core/ProgressHUD.swift
+++ b/VideoApp/VideoApp/NewCode/Views/Core/ProgressHUD.swift
@@ -21,8 +21,8 @@ struct ProgressHUD: View {
     
     var body: some View {
         ZStack {
-            Color.backgroundBrandStronger
-                .opacity(0.8)
+            Color.backgroundBodyInverse
+                .opacity(0.6)
             VStack(spacing: 40) {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle(tint: .green))

--- a/VideoApp/VideoApp/NewCode/Views/FocusLayout/FocusLayoutView.swift
+++ b/VideoApp/VideoApp/NewCode/Views/FocusLayout/FocusLayoutView.swift
@@ -31,17 +31,20 @@ struct FocusLayoutView: View {
         GeometryReader { geometry in
             HStack(spacing: spacing) {
                 VStack(spacing: spacing) {
-                    PresentationStatusView(presenterIdentity: viewModel.presenter.identity)
+                    if viewModel.isPresenting {
+                        PresentationStatusView(presenterIdentity: viewModel.presenter.identity)
+                    }
+                    
                     ParticipantView(viewModel: $viewModel.dominantSpeaker)
 
-                    if isPortraitOrientation {
+                    if isPortraitOrientation && viewModel.isPresenting {
                         PresentationView(videoTrack: $viewModel.presenter.presentationTrack)
                     }
                 }
                 // For landscape orientation only use 30% of the width for stuff that isn't the presentation video
-                .frame(width: isPortraitOrientation ? nil : geometry.size.width * 0.3)
+                .frame(width: isPortraitOrientation || !viewModel.isPresenting ? nil : geometry.size.width * 0.3)
                 
-                if !isPortraitOrientation {
+                if !isPortraitOrientation && viewModel.isPresenting {
                     PresentationView(videoTrack: $viewModel.presenter.presentationTrack)
                 }
             }
@@ -52,16 +55,15 @@ struct FocusLayoutView: View {
 
 struct FocusLayoutView_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
-            FocusLayoutView(spacing: 6)
-                .previewDisplayName("Portrait")
-                .frame(width: 300, height: 600)
-            FocusLayoutView(spacing: 6)
-                .previewDisplayName("Landscape")
-                .frame(width: 600, height: 300)
+        ForEach([false, true], id: \.self) { isPresenting in
+            ForEach([[300.0, 600.0], [600.0, 300.0]], id: \.self) { size in
+                FocusLayoutView(spacing: 6)
+                    .previewDisplayName(isPresenting ? "Presenting" : "Not presenting")
+                    .frame(width: size[0], height: size[1])
+                    .environmentObject(FocusLayoutViewModel.stub(isPresenting: isPresenting))
+                    .previewLayout(.sizeThatFits)
+            }
         }
-        .environmentObject(FocusLayoutViewModel.stub(isPresenting: true))
-        .previewLayout(.sizeThatFits)
     }
 }
 

--- a/VideoApp/VideoApp/NewCode/Views/FocusLayout/FocusLayoutViewModel.swift
+++ b/VideoApp/VideoApp/NewCode/Views/FocusLayout/FocusLayoutViewModel.swift
@@ -54,17 +54,22 @@ class FocusLayoutViewModel: ObservableObject {
     }
 
     private func update() {
-        guard let presenter = findPresenter() else {
-            isPresenting = false
-            presenter = Presenter()
-            dominantSpeaker = ParticipantViewModel()
-            return
-        }
-
-        isPresenting = true
-        self.presenter = presenter
         dominantSpeaker = findDominantSpeaker()
         dominantSpeaker.isDominantSpeaker = false // No need to distinguish in the UI since only 1 participant is shown
+
+        if let presenter = findPresenter() {
+            self.presenter = presenter
+
+            if !isPresenting {
+                isPresenting = true
+            }
+        } else {
+            presenter = Presenter()
+            
+            if isPresenting {
+                isPresenting = false
+            }
+        }
     }
     
     private func findPresenter() -> Presenter? {

--- a/VideoApp/VideoApp/NewCode/Views/FocusLayout/PresentationStatusView.swift
+++ b/VideoApp/VideoApp/NewCode/Views/FocusLayout/PresentationStatusView.swift
@@ -21,7 +21,7 @@ struct PresentationStatusView: View {
     
     var body: some View {
         ZStack {
-            Color.backgroundBrand
+            Color.backgroundInverseStrong
             Text(presenterIdentity + " is presenting.")
                 .foregroundColor(.white)
                 .font(.system(size: 13, weight: .bold))

--- a/VideoApp/VideoApp/NewCode/Views/GridLayout/GridLayoutView.swift
+++ b/VideoApp/VideoApp/NewCode/Views/GridLayout/GridLayoutView.swift
@@ -99,7 +99,7 @@ struct GridLayoutView_Previews: PreviewProvider {
             }
             .frame(width: 700, height: 300)
         }
-        .background(Color.backgroundBrandStronger) // So page index is visible
+        .background(Color.backgroundBodyInverse) // So page index is visible
         .previewLayout(.sizeThatFits)
     }
 }

--- a/VideoApp/VideoApp/NewCode/Views/NetworkQuality/NetworkQualityView.swift
+++ b/VideoApp/VideoApp/NewCode/Views/NetworkQuality/NetworkQualityView.swift
@@ -42,7 +42,7 @@ struct NetworkQualityView_Previews: PreviewProvider {
                 .previewDisplayName("\(index) bars")
         }
         .frame(width: 50)
-        .background(Color.backgroundBrandStronger)
+        .background(Color.backgroundBodyInverse)
         .previewLayout(.sizeThatFits)
     }
 }

--- a/VideoApp/VideoApp/NewCode/Views/Participant/ParticipantView.swift
+++ b/VideoApp/VideoApp/NewCode/Views/Participant/ParticipantView.swift
@@ -55,7 +55,7 @@ struct ParticipantView: View {
                         Image(systemName: "mic.slash")
                             .foregroundColor(.white)
                             .padding(9)
-                            .background(Color.backgroundBrandStronger.opacity(0.4))
+                            .background(Color.backgroundBodyInverse.opacity(0.4))
                             .clipShape(Circle())
                             .padding(8)
                     }
@@ -76,7 +76,7 @@ struct ParticipantView: View {
                     }
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Color.backgroundBrandStronger.opacity(0.7))
+                    .background(Color.backgroundBodyInverse.opacity(0.7))
                     .cornerRadius(2)
                     
                     Spacer()

--- a/VideoApp/VideoApp/NewCode/Views/RoomStatus/RecordingBadge.swift
+++ b/VideoApp/VideoApp/NewCode/Views/RoomStatus/RecordingBadge.swift
@@ -46,7 +46,7 @@ struct RecordingBadge_Previews: PreviewProvider {
     static var previews: some View {
         RecordingBadge()
             .padding()
-            .background(Color.backgroundBrandStronger)
+            .background(Color.backgroundBodyInverse)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/VideoApp/VideoApp/NewCode/Views/RoomStatus/RoomStatusView.swift
+++ b/VideoApp/VideoApp/NewCode/Views/RoomStatus/RoomStatusView.swift
@@ -41,7 +41,7 @@ struct RoomStatusView: View {
                     Image(systemName: "arrow.triangle.2.circlepath.camera")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .padding(11)
+                        .padding(13)
                         .foregroundColor(.white)
                 }
             }
@@ -61,7 +61,7 @@ struct RoomStatusView_Previews: PreviewProvider {
                         .environmentObject(RoomManager.stub(isRecording: isRecording))
                         .environmentObject(LocalParticipantManager.stub(isCameraOn: isCameraOn))
                         .frame(width: 400)
-                        .background(Color.backgroundBrandStronger)
+                        .background(Color.backgroundBodyInverse)
                         .previewLayout(.sizeThatFits)
                 }
             }


### PR DESCRIPTION
1. Allow the user to manually switch between grid and focus layout.
2. Make focus layout display just the dominant speaker when no user is presenting. This way focus layout is useful regardless if there is a presentation or not.
3. Some minor color and copy changes to make more consistent with the web app.

### Focus layout without presention:
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 15 37 58](https://user-images.githubusercontent.com/1930363/159086644-96f3755e-be53-46e8-8d31-d53a67b9568e.png)

### Focus layout with menu option to switch to grid layout:
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 15 37 15](https://user-images.githubusercontent.com/1930363/159086651-d20194f9-bf6a-455d-94e5-689b57e848a8.png)

### Grid layout with option to switch to focus layout:
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 15 37 26](https://user-images.githubusercontent.com/1930363/159086646-5e63221a-0bad-463f-8c45-92aafdb2df66.png)

### Home screen copy changes:
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-18 at 15 33 52](https://user-images.githubusercontent.com/1930363/159086653-4a116be5-05d7-4779-9874-df192e0709b9.png)