### PR TITLE
Small improvements for testing feedback

### DIFF
--- a/VideoApp/VideoApp/SwiftUI/Screens/MediaSetup/MediaSetupViewModel.swift
+++ b/VideoApp/VideoApp/SwiftUI/Screens/MediaSetup/MediaSetupViewModel.swift
@@ -25,7 +25,7 @@ class MediaSetupViewModel: ObservableObject {
         self.localParticipant = localParticipant
 
         localParticipant.changePublisher
-            .map { ParticipantViewModel(participant: $0, shouldDisplayFullName: true) }
+            .map { ParticipantViewModel(participant: $0, shouldHideYou: true) }
             .sink { [weak self] participant in self?.participant = participant }
             .store(in: &subscriptions)
     }

--- a/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomView.swift
+++ b/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomView.swift
@@ -72,12 +72,12 @@ struct RoomView: View {
                             case .grid:
                                 Button(
                                     action: { viewModel.switchToLayout(.focus) },
-                                    label: { Label("Switch to Focus Layout", systemImage: "person") }
+                                    label: { Label("Switch to Presenter View", systemImage: "person") }
                                 )
                             case .focus:
                                 Button(
                                     action: { viewModel.switchToLayout(.grid) },
-                                    label: { Label("Switch to Grid Layout", systemImage: "square.grid.2x2") }
+                                    label: { Label("Switch to Grid View", systemImage: "square.grid.2x2") }
                                 )
                             }
                         } label: {
@@ -94,7 +94,7 @@ struct RoomView: View {
                 StatsContainerView(isShowingStats: $viewModel.isShowingStats)
                 
                 if viewModel.state == .connecting {
-                    ProgressHUD(title: "Connecting...")
+                    ProgressHUD(title: "Joining Meeting")
                 }
             }
         }

--- a/VideoApp/VideoApp/SwiftUI/Views/Participant/ParticipantView.swift
+++ b/VideoApp/VideoApp/SwiftUI/Views/Participant/ParticipantView.swift
@@ -36,7 +36,9 @@ struct ParticipantView: View {
                 /// switch the track on when bandwidth constraints allow. If the video was completely removed from the hierarchy
                 /// the server would never switch the track on.
                 ZStack {
-                    Color.black // For black bars
+                    if !viewModel.shouldFillCameraVideo {
+                        Color.black // For black bars
+                    }
 
                     SwiftUIVideoView(
                         videoTrack: $viewModel.cameraTrack,

--- a/VideoApp/VideoApp/SwiftUI/Views/Participant/ParticipantViewModel.swift
+++ b/VideoApp/VideoApp/SwiftUI/Views/Participant/ParticipantViewModel.swift
@@ -35,9 +35,9 @@ struct ParticipantViewModel {
         
     }
 
-    init(participant: LocalParticipantManager, shouldDisplayFullName: Bool = false) {
+    init(participant: LocalParticipantManager, shouldHideYou: Bool = false) {
         identity = participant.identity
-        displayName = shouldDisplayFullName ? identity : "You"
+        displayName = identity + (shouldHideYou ? "" : " (You)")
         isYou = true
         isMuted = !participant.isMicOn
 


### PR DESCRIPTION
1. Reduce video flicker when track is shown or getting switched back on. There was both a blue (from the view that is shown when camera is off) and black flash so the flicker was particularly bad. I got rid of the black flash. Might be able to improve the blue flash later.
2. Display `Bob (You)` instead of just `You`. This is more consistent with the web app.
3. A couple copy changes.