### PR TITLE
Improve release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ workflows:
       #     filters: *test_filters
       - deploy_internal_app_beta:
           filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
             branches:
-              only:
-                - master
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.1.9 (April 21, 2022)
+
+### Maintenance
+
+- Improve release process used for internal testing.
+- Use semantic versioning for the app version number.
+
 ## 0.95 (March 31, 2022)
 
 ### New Features

--- a/ForTwilions.md
+++ b/ForTwilions.md
@@ -20,11 +20,9 @@ Twilio employees should follow these instructions for internal testing.
 1. Select `Video-Internal` scheme.
 1. Run `⌘R` the app.
 
-## UI Tests
+## Release
 
-For UI tests use:
-
-- `Video-InternalUITests` scheme.
-- `Video-InternalUITests` target. 
-- `UI` test plan.
-- [Nimble](https://github.com/Quick/Quick) for assertions.
+1. Merge work to `master` branch.
+1. Make sure `CHANGELOG.md` contains the correct release notes.
+1. Create a release in GitHub. Use app version for the tag name, such as `1.8.2`. Copy release notes from `CHANGELOG.md`. 
+1. CI will automatically build the release and upload it to App Center. 

--- a/VideoApp/Video-CommunityTests/Info.plist
+++ b/VideoApp/Video-CommunityTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.8</string>
 	<key>CFBundleVersion</key>
 	<string>95</string>
 </dict>

--- a/VideoApp/Video-InternalTests/Info.plist
+++ b/VideoApp/Video-InternalTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.8</string>
 	<key>CFBundleVersion</key>
 	<string>95</string>
 </dict>

--- a/VideoApp/Video-InternalTests/Specs/AppInfoStoreSpec.swift
+++ b/VideoApp/Video-InternalTests/Specs/AppInfoStoreSpec.swift
@@ -34,12 +34,6 @@ class AppInfoStoreSpec: QuickSpec {
                 }
             }
 
-            describe("build") {
-                it("is not empty") {
-                    expect(sut.appInfo.build.isEmpty).to(beFalse())
-                }
-            }
-
             describe("target") {
                 it("is videoInternal") {
                     expect(sut.appInfo.target).to(equal(.videoInternal))

--- a/VideoApp/Video-InternalTests/Stubs/StubAppInfo.swift
+++ b/VideoApp/Video-InternalTests/Stubs/StubAppInfo.swift
@@ -20,9 +20,8 @@ extension AppInfo {
     static func stub(
         appCenterAppSecret: String = "",
         version: String = "",
-        build: String = "",
         target: Target = .videoInternal
     ) -> AppInfo {
-        .init(appCenterAppSecret: appCenterAppSecret, version: version, build: build, target: target)
+        .init(appCenterAppSecret: appCenterAppSecret, version: version, target: target)
     }
 }

--- a/VideoApp/Video-InternalUITests/Info.plist
+++ b/VideoApp/Video-InternalUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.8</string>
 	<key>CFBundleVersion</key>
 	<string>95</string>
 </dict>

--- a/VideoApp/VideoApp/Info.plist
+++ b/VideoApp/VideoApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>0.1.8</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/VideoApp/VideoApp/Stores/AppInfo/AppInfo.swift
+++ b/VideoApp/VideoApp/Stores/AppInfo/AppInfo.swift
@@ -24,6 +24,5 @@ struct AppInfo {
     
     let appCenterAppSecret: String
     let version: String
-    let build: String
     let target: Target
 }

--- a/VideoApp/VideoApp/Stores/AppInfo/AppInfoStore.swift
+++ b/VideoApp/VideoApp/Stores/AppInfo/AppInfoStore.swift
@@ -25,7 +25,6 @@ class AppInfoStore: AppInfoStoreReading {
         AppInfo(
             appCenterAppSecret: bundle.object(forInfoDictionaryKey: "AppCenterAppSecret") as! String,
             version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String,
-            build: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as! String,
             target: AppInfo.Target(rawValue: bundle.object(forInfoDictionaryKey: "TargetName") as! String)!
         )
     }

--- a/VideoApp/VideoApp/UIKit/Settings/General/GeneralSettingsViewModel.swift
+++ b/VideoApp/VideoApp/UIKit/Settings/General/GeneralSettingsViewModel.swift
@@ -24,7 +24,7 @@ class GeneralSettingsViewModel: SettingsViewModel {
                 rows: [
                     .info(
                         title: "App Version",
-                        detail: "\(appInfoStore.appInfo.version) (\(appInfoStore.appInfo.build))"
+                        detail: appInfoStore.appInfo.version
                     ),
                     .info(
                         title: "SDK Version",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,8 +28,8 @@ platform :ios do
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
       # push_to_git_remote(remote_branch: "master")
-      # push_to_git_remote(remote_branch: "task/tag-release")
-      sh("git", "push", "origin", "task/tag-release") # test
+      push_to_git_remote(remote_branch: "task/tag-release")
+      # sh("git", "push", "origin", "task/tag-release") # test
     end
 
     gym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,7 +27,7 @@ platform :ios do
     if get_version_number(xcodeproj: project_path, target: "Video-Internal") != tag
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
-      push_to_git_remote(remote_branch: ENV["CIRCLE_BRANCH"])
+      push_to_git_remote
     end
 
     gym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ platform :ios do
     tag = ENV["CIRCLE_TAG"]
     project_path = "VideoApp/VideoApp.xcodeproj"
 
-    if get_version_number(xcodeproj: project_path) != tag
+    if get_version_number(xcodeproj: project_path, target: "Video-Internal") != tag
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
       push_to_git_remote(remote_branch: ENV["CIRCLE_BRANCH"])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,7 +27,8 @@ platform :ios do
     if get_version_number(xcodeproj: project_path, target: "Video-Internal") != tag
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
-      push_to_git_remote
+      # push_to_git_remote(remote_branch: "master")
+      push_to_git_remote(remote_branch: "task/tag-release")
     end
 
     gym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :ios do
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
       # push_to_git_remote(remote_branch: "master")
       # push_to_git_remote(remote_branch: "task/tag-release")
-      sh("git", "push", "origin", "task/tag-release")
+      sh("git", "push", "origin", "task/tag-release") # test
     end
 
     gym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,7 @@ platform :ios do
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
       # push_to_git_remote(remote_branch: "master")
-      push_to_git_remote(remote_branch: "task/tag-release")
+      push_to_git_remote(local_branch: "HEAD", remote_branch: "task/tag-release")
       # sh("git", "push", "origin", "task/tag-release") # test
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,9 +27,7 @@ platform :ios do
     if get_version_number(xcodeproj: project_path, target: "Video-Internal") != tag
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
-      # push_to_git_remote(remote_branch: "master")
-      push_to_git_remote(local_branch: "HEAD", remote_branch: "task/tag-release")
-      # sh("git", "push", "origin", "task/tag-release") # test
+      push_to_git_remote(local_branch: "HEAD", remote_branch: "master")
     end
 
     gym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,8 @@ platform :ios do
       increment_version_number(version_number: tag, xcodeproj: project_path)
       commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
       # push_to_git_remote(remote_branch: "master")
-      push_to_git_remote(remote_branch: "task/tag-release")
+      # push_to_git_remote(remote_branch: "task/tag-release")
+      sh("git", "push", "origin", "task/tag-release")
     end
 
     gym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,10 +21,14 @@ platform :ios do
   lane :beta do
     cocoapods
     ensure_git_status_clean
-    build_number = increment_build_number(xcodeproj: "VideoApp/VideoApp.xcodeproj")
-    commit_version_bump(message: "Increment build number [skip ci]", xcodeproj: "VideoApp/VideoApp.xcodeproj")
-    add_git_tag(tag: "v0.#{build_number}")
-    push_to_git_remote
+    tag = ENV["CIRCLE_TAG"]
+    project_path = "VideoApp/VideoApp.xcodeproj"
+
+    if get_version_number(xcodeproj: project_path) != tag
+      increment_version_number(version_number: tag, xcodeproj: project_path)
+      commit_version_bump(message: "Increment version number [skip ci]", xcodeproj: project_path)
+      push_to_git_remote(remote_branch: ENV["CIRCLE_BRANCH"])
+    end
 
     gym(
       scheme: "Video-Internal",
@@ -37,12 +41,20 @@ platform :ios do
 
     upload_symbols_to_crashlytics()
 
+    release = get_github_release(
+      url: "twilio/twilio-video-app-ios", 
+      version: tag,
+      api_token: ENV["GITHUB_API_TOKEN"]
+    )
+
     appcenter_upload(
       api_token: ENV["APP_CENTER_API_KEY"],
       owner_name: ENV["APP_CENTER_OWNER_NAME"],
       app_name: "Ahoy-Video-App-Internal",
       destinations: "Testers",
-      file: "Video-Internal.ipa"
+      file: "Video-Internal.ipa",
+      notify_testers: true,
+      release_notes: release["body"]      
     )
   end
 


### PR DESCRIPTION
1. CI will build and distribute app when GitHub release is created. See `ForTwilions.md` for details.
2. Use semantic versioning for app version. Previously only the build number was incremented and we were displaying the build number as a version in some places.