### PR TITLE
Captions bug fixes

### DIFF
--- a/VideoApp/VideoApp/API/CreateTwilioAccessTokenRequest.swift
+++ b/VideoApp/VideoApp/API/CreateTwilioAccessTokenRequest.swift
@@ -22,6 +22,7 @@ struct CreateTwilioAccessTokenRequest: APIRequest {
         let userIdentity: String
         let roomName: String?
         let createRoom: Bool
+        let createConversation = true /// For captions beta so that the server can store the media processor SID
     }
 
     let path = "token"

--- a/VideoApp/VideoApp/Helpers/VideoAppError.swift
+++ b/VideoApp/VideoApp/Helpers/VideoAppError.swift
@@ -17,6 +17,7 @@
 import Foundation
 
 enum VideoAppError: Error {
+    case stringIsNotUTF8
     case transcriberError
     case mediaTranscriberNotConnected
 }
@@ -24,6 +25,7 @@ enum VideoAppError: Error {
 extension VideoAppError: LocalizedError {
     var errorDescription: String? {
         switch self {
+        case .stringIsNotUTF8: return "String is not UTF8."
         case .transcriberError: return "Transcriber error."
         case .mediaTranscriberNotConnected: return "Media transcriber not connected."
         }

--- a/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomViewModel.swift
@@ -40,6 +40,10 @@ import Combine
     @Published var isShowingStats = false
     @Published var isShowingCaptions = false {
         didSet {
+            guard captionsManager != nil else {
+                return /// When not configured do nothing so preview doesn't crash
+            }
+
             captionsManager.isCaptionsEnabled = isShowingCaptions
         }
     }

--- a/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomViewModel.swift
+++ b/VideoApp/VideoApp/SwiftUI/Screens/Room/RoomViewModel.swift
@@ -74,12 +74,11 @@ import Combine
             .sink { [weak self] error in self?.handleError(error) }
             .store(in: &subscriptions)
         
-        captionsManager.$error
+        captionsManager.errorPublisher
             .sink { [weak self] error in
-                guard let error = error else { return }
-
                 self?.error = error
                 self?.alertIdentifier = .informativeError
+                self?.isShowingCaptions = false
             }
             .store(in: &subscriptions)
 
@@ -106,6 +105,7 @@ import Combine
     }
     
     func disconnect() {
+        captionsManager.isCaptionsEnabled = false
         roomManager.disconnect()
         state = .disconnected
         roomManager.localParticipant.isMicOn = false

--- a/VideoApp/VideoApp/TwilioVideo/Captions/Caption.swift
+++ b/VideoApp/VideoApp/TwilioVideo/Captions/Caption.swift
@@ -27,7 +27,7 @@ struct Caption: Hashable {
             return nil
         }
 
-        userIdentity = result.ParticipantIdentity
+        userIdentity = result.Identity
         message = transcript
         id = result.ResultId
     }

--- a/VideoApp/VideoApp/TwilioVideo/Captions/CaptionsManager.swift
+++ b/VideoApp/VideoApp/TwilioVideo/Captions/CaptionsManager.swift
@@ -28,7 +28,7 @@ class CaptionsManager: NSObject, ObservableObject {
         didSet {
             guard oldValue != isCaptionsEnabled else { return }
 
-            setup()
+            reset()
         }
     }
 
@@ -36,34 +36,47 @@ class CaptionsManager: NSObject, ObservableObject {
         didSet {
             guard oldValue != transcriber else { return }
 
-            oldValue?.removeDelegates() /// In case the transcriber disconnected which should not happen
-            setup()
+            oldValue?.removeDelegates()
+            reset()
         }
     }
 
     private var subscriptions = Set<AnyCancellable>()
 
-    private func setup() {
+    private func reset() {
         transcriber?.removeDelegates()
         error = nil
         captions.removeAll()
         subscriptions.removeAll()
 
-        if let transcriber = transcriber, isCaptionsEnabled {
-            transcriber.delegate = self
-            
-            Timer.publish(every: 1, on: .main, in: .default)
-                .autoconnect()
-                .sink { [weak self] date in
-                    self?.captions.removeAll(where: { date.timeIntervalSince($0.date) > 10 })
-                }
-                .store(in: &subscriptions)
-            
-            if transcriber.remoteDataTracks.first(where: { $0.remoteTrack?.isTranscriberError ?? false }) != nil {
-                /// Using the presence of this data track to signal the transcriber is not working correctly
-                error = VideoAppError.transcriberError
-            }
+        guard isCaptionsEnabled else {
+            return
         }
+        
+        guard let transcriber = transcriber else {
+            handleError(VideoAppError.mediaTranscriberNotConnected)
+            return
+        }
+        
+        guard !transcriber.hasTranscriberError else {
+            handleError(VideoAppError.transcriberError)
+            return
+        }
+        
+        transcriber.delegate = self
+        transcriber.remoteDataTracks.forEach { $0.remoteTrack?.delegate = self }
+        
+        Timer.publish(every: 1, on: .main, in: .default)
+            .autoconnect()
+            .sink { [weak self] date in
+                self?.captions.removeAll(where: { date.timeIntervalSince($0.date) > 10 })
+            }
+            .store(in: &subscriptions)
+    }
+    
+    private func handleError(_ error: Error) {
+        isCaptionsEnabled = false /// Do this first because it will cause the error to be cleared
+        self.error = error
     }
 }
 
@@ -74,33 +87,29 @@ extension CaptionsManager: RemoteParticipantDelegate {
         participant: RemoteParticipant
     ) {
         if dataTrack.isTranscriberError {
-            /// Using the presence of this data track to signal the transcriber is not working correctly
-            error = VideoAppError.transcriberError
+            handleError(VideoAppError.transcriberError)
         } else {
             dataTrack.delegate = self
-        }
-    }
-    
-    func didUnsubscribeFromDataTrack(
-        dataTrack: RemoteDataTrack,
-        publication: RemoteDataTrackPublication,
-        participant: RemoteParticipant
-    ) {
-        if dataTrack.isTranscriberError {
-            error = nil
         }
     }
 }
 
 extension CaptionsManager: RemoteDataTrackDelegate {
     func remoteDataTrackDidReceiveString(remoteDataTrack: RemoteDataTrack, message: String) {
-        guard
-            let data = message.data(using: .utf8),
-            let transcription = try? JSONDecoder().decode(Transcription.self, from: data)
-        else {
+        guard let data = message.data(using: .utf8) else {
+            handleError(VideoAppError.stringIsNotUTF8)
             return
         }
+
+        let transcription: Transcription
         
+        do {
+            transcription = try JSONDecoder().decode(Transcription.self, from: data)
+        } catch {
+            handleError(error)
+            return
+        }
+
         transcription.transcriptionResponse.TranscriptEvent.Transcript.Results
             .compactMap { Caption(result: $0) }
             .forEach { caption in
@@ -118,6 +127,10 @@ extension CaptionsManager: RemoteDataTrackDelegate {
 }
 
 private extension RemoteParticipant {
+    var hasTranscriberError: Bool {
+        remoteDataTracks.first { $0.remoteTrack?.isTranscriberError ?? false } == nil
+    }
+    
     func removeDelegates() {
         delegate = nil
         remoteDataTracks.forEach { $0.remoteTrack?.delegate = nil }
@@ -126,6 +139,7 @@ private extension RemoteParticipant {
 
 private extension RemoteDataTrack {
     var isTranscriberError: Bool {
+        /// Use the presence of this data track to signal the transcriber is not working correctly
         name == "transcriber-error"
     }
 }

--- a/VideoApp/VideoApp/TwilioVideo/Captions/Transcription.swift
+++ b/VideoApp/VideoApp/TwilioVideo/Captions/Transcription.swift
@@ -26,7 +26,7 @@ struct Transcription: Decodable {
                     }
                     
                     let ResultId: String
-                    let ParticipantIdentity: String
+                    let Identity: String
                     let Alternatives: [Alternative]
                 }
                 


### PR DESCRIPTION
1. Had to rename `ParticipantIdentity` to `Identity` to match what the transcriber was providing.
2. Simplified captions error handling. Previously errors would not cause captions to stop. This got to be complex to manage the various states and was causing problems. Now when there is an error the captions will stop. The user will have to restart captions if they want to try captions again.
3. Unrelated to captions, API error handling wasn't quite right so I fixed that.