### PR TITLE
Use StackNavigationViewStyle to render HomeView correctly on iPadOS

### DIFF
--- a/VideoApp/VideoApp/SwiftUI/Screens/Home/HomeView.swift
+++ b/VideoApp/VideoApp/SwiftUI/Screens/Home/HomeView.swift
@@ -69,6 +69,8 @@ struct HomeView: View {
                 RoomViewDependencyWrapper(roomName: roomName)
             }
         }
+        // Note: StackNavigationViewStyle is deprecated from iOS 16.0 onwards. Use NavigationStack view instead.
+        .navigationViewStyle(StackNavigationViewStyle())
         .onAppear {
             callManager.configure(roomManager: roomManager)
             roomManager.configure(localParticipant: localParticipant)


### PR DESCRIPTION
Added navigationViewStyle modifier on HomeView's NavigationView to prevent it from being hidden away in portrait mode on iPadOS.
