### PR TITLE
Update Video iOS SDK to 5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.18 (February 28, 2024)
+
+### Maintenance
+
+- Updated Video iOS SDK version to 5.8.0.
+
 ## 0.1.17 (September 30, 2022)
 
 ### Maintenance

--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -2863,7 +2863,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.3.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoApp/VideoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VideoApp/VideoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/twilio/twilio-video-ios",
       "state" : {
-        "revision" : "4f3c31a7f49bc92738faca8612532aa1d1590573",
-        "version" : "5.3.0"
+        "revision" : "d2d87e3780cd4b1571f26fe4566d950a997ab154",
+        "version" : "5.8.0"
       }
     }
   ],


### PR DESCRIPTION
<!-- Describe your Pull Request -->
#### 5.8.0 (February 28, 2024)
Enhancements
- This version contains 'VideoTrackStoringSampleBufferVideoView' class which simplifies the implementation of Picture in Picture.
- This release is based on Chromium WebRTC 112.
- iSAC Codec is no longer supported.

Known Issues
- Audio playback fails in some cases when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
