### PR TITLE
Update Video iOS SDK to 5.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.20 (May 9, 2024)
+
+### Maintenance
+
+- Updated Video iOS SDK version to 5.8.2.
+
 ## 0.1.19 (April 28, 2024)
 
 ### Maintenance

--- a/VideoApp/VideoApp.xcodeproj/project.pbxproj
+++ b/VideoApp/VideoApp.xcodeproj/project.pbxproj
@@ -2863,7 +2863,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.1;
+				minimumVersion = 5.8.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoApp/VideoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VideoApp/VideoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/twilio/twilio-video-ios",
       "state" : {
-        "revision" : "4c065eb3378db1f7b83e3169f4aca0509a045c96",
-        "version" : "5.8.1"
+        "revision" : "1cf453f4a2de505f7346fde6085c299144f05941",
+        "version" : "5.8.2"
       }
     }
   ],


### PR DESCRIPTION
<!-- Describe your Pull Request -->
#### 5.8.2 (May 9, 2024)

* Programmable Video iOS SDK 5.8.2 [[XCFramework]](https://github.com/twilio/twilio-video-ios/releases/download/5.8.2/TwilioVideo.xcframework.zip) (checksum: XCFRAMEWORK_CHECKSUM).

Enhancements
- The Privacy Manifest is updated since the SDK does not collect API usage or call quality data for tracking purposes according to [Apple's documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).

Known Issues
- Audio playback fails in some cases when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
